### PR TITLE
feat: add `getContext` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "prepare": "husky install",
     "lint": "eslint --cache --report-unused-disable-directives --ignore-path .gitignore --max-warnings=0 . --fix",
     "lint:ci": "eslint --cache --report-unused-disable-directives --ignore-path .gitignore --max-warnings=0 .",
-    "build": "npm run build",
-    "test": "npm run test",
     "format": "prettier --write .",
     "format:ci": "prettier --check ."
   },

--- a/packages/cache/src/bootstrap/cache.test.ts
+++ b/packages/cache/src/bootstrap/cache.test.ts
@@ -37,9 +37,7 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getHost: () => host,
-        getToken: () => token,
-        getURL: () => url,
+        getContext: () => ({ host, token, url }),
         name: 'my-cache',
         userAgent,
       })
@@ -86,9 +84,7 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getHost: () => host,
-        getToken: () => token,
-        getURL: () => url,
+        getContext: () => ({ host, token, url }),
         name: 'my-cache',
         userAgent,
       })
@@ -129,9 +125,7 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getHost: () => host,
-        getToken: () => token,
-        getURL: () => url,
+        getContext: () => ({ host, token, url }),
         name: 'my-cache',
         userAgent,
       })
@@ -172,9 +166,7 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getHost: () => host,
-        getToken: () => token,
-        getURL: () => url,
+        getContext: () => ({ host, token, url }),
         name: 'my-cache',
         userAgent,
       })

--- a/packages/cache/src/bootstrap/environment.ts
+++ b/packages/cache/src/bootstrap/environment.ts
@@ -1,10 +1,15 @@
 export type Base64Encoder = (input: string) => string
-export type Factory<T> = () => T
 
 export interface EnvironmentOptions {
   base64Encode: Base64Encoder
-  getHost: Factory<string>
-  getToken: Factory<string>
-  getURL: Factory<string>
+  getContext: RequestContextFactory
   userAgent?: string
+}
+
+export type RequestContextFactory = () => RequestContext
+
+export interface RequestContext {
+  host: string
+  token: string
+  url: string
 }

--- a/packages/cache/src/bootstrap/main.ts
+++ b/packages/cache/src/bootstrap/main.ts
@@ -1,8 +1,3 @@
-import { Base64Encoder, Factory } from './environment.ts'
-
-export type { Base64Encoder }
-export type HostFactory = Factory<string>
-export type TokenFactory = Factory<string>
-export type URLFactory = Factory<string>
+export type { Base64Encoder, RequestContextFactory } from './environment.ts'
 export { NetlifyCache } from './cache.ts'
 export { NetlifyCacheStorage } from './cachestorage.ts'

--- a/packages/cache/src/fetchwithcache.test.ts
+++ b/packages/cache/src/fetchwithcache.test.ts
@@ -20,9 +20,7 @@ let originalCaches = globalThis.caches
 beforeAll(() => {
   globalThis.caches = new NetlifyCacheStorage({
     base64Encode,
-    getHost: () => host,
-    getToken: () => token,
-    getURL: () => url,
+    getContext: () => ({ host, token, url }),
   })
 })
 


### PR DESCRIPTION
When integrating this with the edge functions bootstrap, I realised it would be more convenient if consumers of this package could expose a single method that retrieve all the request-level context as opposed to calling different methods for each.

So in this PR I'm replacing the `getHost`, `getToken` and `getURL` methods with a single `getContext` method.