### PR TITLE
fix: disable code-splitting to workaround an issue in deno 2.x's `deno cache` functionality

### DIFF
--- a/packages/cache/build.mjs
+++ b/packages/cache/build.mjs
@@ -12,6 +12,7 @@ await rm(dist, { recursive: true, force: true })
 const options = {
   entry: ['src/bootstrap/main.ts', 'src/main.ts'],
   tsconfig: 'tsconfig.json',
+  splitting: false,
   bundle: true,
   dts: true,
   outDir: dist,


### PR DESCRIPTION
currently this package is published in this structure:
```
dist/
├── bootstrap
│   ├── main.cjs
│   ├── main.d.cts
│   ├── main.d.ts
│   └── main.js
├── cache-854474ad.d.ts
├── chunk-DZNRKSSF.js
├── main.cjs
├── main.d.cts
├── main.d.ts
└── main.js
```

if we try to cache this package using deno, right now it will end up with a file structure like this:
```
vendor
├── cdn.jsdelivr.net
│   └── npm
│       └── @netlify
│           └── cache@1.3.0
│               └── dist
│                   ├── #chunk-i5fzdz6v_a8179.js
│                   └── bootstrap
│                       └── main.js
```

this is incorrect because ./dist/bootstrap/main.js wants to import from `"../chunk-I5FZDZ6V.js"` but that file does not exist, deno has named the file `#chunk-i5fzdz6v_a8179.js`

we can work around this issue by ensuring we do not code split the files, so that our published package becomes this:
```
dist/
├── bootstrap
│   ├── main.cjs
│   ├── main.d.cts
│   ├── main.d.ts
│   └── main.js
├── cache-854474ad.d.ts
├── main.cjs
├── main.d.cts
├── main.d.ts
└── main.js
```