### PR TITLE
chore: add a last-release-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "9ae97887beb38dd7eea0f3f90111b9a73e984592",
+  "last-release-sha": "8f0c83b0ed237c790be46b926a5626ebf5a2e232",
   "plugins": ["node-workspace"],
   "packages": {
     "packages/cache": {


### PR DESCRIPTION
release-please's normal behavior is to find the last merged release PR and use the associated commit sha as the previous marker from which to gather commits for the new release. With this setting you can manually set the commit sha release-please will use from which to gather commits for the current release.

we will use this to ensure that release-please does not copy over the changes from 1.4.0 into the changes for 1.5.0