### PR TITLE
remove last-release-sha now that the release has gone out

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "9ae97887beb38dd7eea0f3f90111b9a73e984592",
-  "last-release-sha": "8f0c83b0ed237c790be46b926a5626ebf5a2e232",
   "plugins": ["node-workspace"],
   "packages": {
     "packages/cache": {


### PR DESCRIPTION
based on the recommendation from the release-please docs https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md

>  // Notes:
>  //   - full sha required.
>  //   - only applicable at top-level config.
>  //   - never ignored: remove/change it once a good release PR is merged