### PR TITLE
feat: make Cache API operations no-ops when context is null

### DIFF
--- a/packages/cache/src/bootstrap/cache.test.ts
+++ b/packages/cache/src/bootstrap/cache.test.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'node:buffer'
 import { describe, test, expect, vi } from 'vitest'
 
 import { NetlifyCache } from './cache.js'
+import { Operation } from './environment.js'
 import { ERROR_CODES } from './errors.js'
 import { getMockFetch } from '../test/fetch.js'
 import { decodeHeaders } from '../test/headers.js'
@@ -38,8 +39,8 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('post')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Write)
 
           return { host, token, url }
         },
@@ -89,8 +90,8 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('delete')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Delete)
 
           return { host, token, url }
         },
@@ -109,8 +110,8 @@ describe('Cache API', () => {
       const mockFetch = getMockFetch()
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('delete')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Delete)
 
           return null
         },
@@ -154,8 +155,8 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('get')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Read)
 
           return { host, token, url }
         },
@@ -184,8 +185,8 @@ describe('Cache API', () => {
       const mockFetch = getMockFetch()
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('get')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Read)
 
           return null
         },
@@ -219,8 +220,8 @@ describe('Cache API', () => {
       })
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('post')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Write)
 
           return { host, token, url }
         },
@@ -297,8 +298,8 @@ describe('Cache API', () => {
       const mockFetch = getMockFetch()
       const cache = new NetlifyCache({
         base64Encode,
-        getContext: ({ method }) => {
-          expect(method).toBe('post')
+        getContext: ({ operation }) => {
+          expect(operation).toBe(Operation.Write)
 
           return null
         },

--- a/packages/cache/src/bootstrap/cache.ts
+++ b/packages/cache/src/bootstrap/cache.ts
@@ -1,4 +1,4 @@
-import type { Base64Encoder, EnvironmentOptions, RequestContext, RequestContextFactory } from './environment.js'
+import { Base64Encoder, EnvironmentOptions, RequestContext, Operation, RequestContextFactory } from './environment.js'
 
 import { ERROR_CODES, GENERIC_ERROR } from './errors.js'
 import * as HEADERS from '../headers.js'
@@ -79,7 +79,7 @@ export class NetlifyCache implements Cache {
 
   // eslint-disable-next-line class-methods-use-this, require-await, @typescript-eslint/no-unused-vars
   async delete(request: RequestInfo) {
-    const context = this.#getContext({ method: 'delete' })
+    const context = this.#getContext({ operation: Operation.Delete })
 
     if (context) {
       const resourceURL = extractAndValidateURL(request)
@@ -101,7 +101,7 @@ export class NetlifyCache implements Cache {
 
   async match(request: RequestInfo) {
     try {
-      const context = this.#getContext({ method: 'get' })
+      const context = this.#getContext({ operation: Operation.Read })
 
       if (!context) {
         return
@@ -152,7 +152,7 @@ export class NetlifyCache implements Cache {
       throw new TypeError("Cannot cache response with 'Vary: *' header.")
     }
 
-    const context = this.#getContext({ method: 'post' })
+    const context = this.#getContext({ operation: Operation.Write })
 
     if (!context) {
       return

--- a/packages/cache/src/bootstrap/environment.ts
+++ b/packages/cache/src/bootstrap/environment.ts
@@ -6,9 +6,13 @@ export interface EnvironmentOptions {
   userAgent?: string
 }
 
-type Method = 'delete' | 'get' | 'post'
+export const enum Operation {
+  Delete = 'delete',
+  Read = 'read',
+  Write = 'write',
+}
 
-export type RequestContextFactory = (opts: { method: Method }) => RequestContext | null
+export type RequestContextFactory = (options: { operation: Operation }) => RequestContext | null
 
 export interface RequestContext {
   host: string

--- a/packages/cache/src/bootstrap/main.ts
+++ b/packages/cache/src/bootstrap/main.ts
@@ -1,3 +1,3 @@
-export type { Base64Encoder, RequestContextFactory } from './environment.ts'
+export { Base64Encoder, Operation, RequestContextFactory } from './environment.ts'
 export { NetlifyCache } from './cache.ts'
 export { NetlifyCacheStorage } from './cachestorage.ts'


### PR DESCRIPTION
Updates the `getContext` callback to receive an options argument with a `method` property. This contains the method of the operation that the client wants to perform (`delete`, `get` or `post`), allowing the bootstrap layer to keep track of what operations are taking place (and how many).

The return value also changes, allowing the callback to return `null`. When this happens, the client makes all operations no-ops. This will be useful in different ways: in a first phase, it lets us expose the Cache API in local development without connecting it to any actual cache engine; it also lets us block operations at the bootstrap level if users go beyond a certain limit.