### PR TITLE
fix: emit `Operation` enum

### DIFF
--- a/packages/cache/src/bootstrap/environment.ts
+++ b/packages/cache/src/bootstrap/environment.ts
@@ -6,7 +6,7 @@ export interface EnvironmentOptions {
   userAgent?: string
 }
 
-export const enum Operation {
+export enum Operation {
   Delete = 'delete',
   Read = 'read',
   Write = 'write',


### PR DESCRIPTION
We want the `Operation` enum to be emitted in the compiled code.

See:

https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAYwgOwM72MgrgWzgeTGCgEMYBLFARjgG8AoOOAEWABtgZg4BeOAcgAm7TsH4AaRnABKwEoN4CocwRKkB1KOS6L+Ady1c1AX3r1QkWHEy4CRUhRQAmOlNYcdfISKOSms+V1leTUmTW1uLwMIkzMgA