### PR TITLE
feat: add `logger` option

### DIFF
--- a/packages/cache/src/bootstrap/cache.test.ts
+++ b/packages/cache/src/bootstrap/cache.test.ts
@@ -256,7 +256,7 @@ describe('Cache API', () => {
     })
 
     test('logs a message when the response is not added to the cache', async () => {
-      const consoleWarn = vi.spyOn(globalThis.console, 'warn')
+      const logger = vi.fn()
       const mockFetch = getMockFetch({
         responses: {
           'https://example.netlify/.netlify/cache/https%3A%2F%2Fnetlify.com%2F': [
@@ -274,6 +274,7 @@ describe('Cache API', () => {
       const cache = new NetlifyCache({
         base64Encode,
         getContext: () => ({ host, token, url }),
+        logger,
         name: 'my-cache',
         userAgent,
       })
@@ -288,8 +289,7 @@ describe('Cache API', () => {
 
       mockFetch.restore()
 
-      expect(consoleWarn).toHaveBeenCalledWith(`Failed to write to the cache: ${ERROR_CODES.no_ttl}`)
-      consoleWarn.mockRestore()
+      expect(logger).toHaveBeenCalledWith(`Failed to write to the cache: ${ERROR_CODES.no_ttl}`)
 
       expect(mockFetch.requests.length).toBe(1)
     })

--- a/packages/cache/src/bootstrap/cache.ts
+++ b/packages/cache/src/bootstrap/cache.ts
@@ -1,4 +1,11 @@
-import { Base64Encoder, EnvironmentOptions, RequestContext, Operation, RequestContextFactory } from './environment.js'
+import {
+  Base64Encoder,
+  EnvironmentOptions,
+  Logger,
+  RequestContext,
+  Operation,
+  RequestContextFactory,
+} from './environment.js'
 
 import { ERROR_CODES, GENERIC_ERROR } from './errors.js'
 import * as HEADERS from '../headers.js'
@@ -19,12 +26,14 @@ const serializeResourceHeaders = Symbol('serializeResourceHeaders')
 export class NetlifyCache implements Cache {
   #base64Encode: Base64Encoder
   #getContext: RequestContextFactory
+  #logger?: Logger
   #name: string
   #userAgent?: string
 
-  constructor({ base64Encode, getContext, name, userAgent }: NetlifyCacheOptions) {
+  constructor({ base64Encode, getContext, logger, name, userAgent }: NetlifyCacheOptions) {
     this.#base64Encode = base64Encode
     this.#getContext = getContext
+    this.#logger = logger
     this.#name = name
     this.#userAgent = userAgent
   }
@@ -176,7 +185,7 @@ export class NetlifyCache implements Cache {
       const errorDetail = cacheResponse.headers.get(HEADERS.ErrorDetail) ?? ''
       const errorMessage = ERROR_CODES[errorDetail as keyof typeof ERROR_CODES] || GENERIC_ERROR
 
-      console.warn(`Failed to write to the cache: ${errorMessage}`)
+      this.#logger?.(`Failed to write to the cache: ${errorMessage}`)
     }
   }
 }

--- a/packages/cache/src/bootstrap/environment.ts
+++ b/packages/cache/src/bootstrap/environment.ts
@@ -1,8 +1,11 @@
 export type Base64Encoder = (input: string) => string
 
+export type Logger = (...args: any[]) => void
+
 export interface EnvironmentOptions {
   base64Encode: Base64Encoder
   getContext: RequestContextFactory
+  logger?: Logger
   userAgent?: string
 }
 


### PR DESCRIPTION
Accepts a custom logger as opposed to using `globalThis.console` directly. 