### PR TITLE
chore: generate provenance statements for npm

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -35,34 +35,34 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
       - name: Build packages
         if: ${{ steps.release.outputs.releases_created }}
-        run: npm run build -ws              
-      
+        run: npm run build -ws
+
       # Publishing packages in topological order, as defined in `package.json`.
-      - run: npm publish packages/dev-utils/ --access=public
+      - run: npm publish packages/dev-utils/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/dev-utils--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/blobs/ --access=public
+      - run: npm publish packages/blobs/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/blobs--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/cache/ --access=public
+      - run: npm publish packages/cache/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/cache--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/functions/ --access=public
+      - run: npm publish packages/functions/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/functions--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/redirects/ --access=public
+      - run: npm publish packages/redirects/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/redirects--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/static/ --access=public
+      - run: npm publish packages/static/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/static--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/dev/ --access=public
+      - run: npm publish packages/dev/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/dev--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
https://docs.npmjs.com/generating-provenance-statements

This was not ported over when moving from individual repos to this monorepo - https://github.com/netlify/functions/blob/0a197b77e634ee982328a5e3f1ae6cfb0fdbea2e/.github/workflows/release-please.yml#L35 for example had it.

workflow already requests `id-token: write` permission which is required for npm provenance, so this is already handled https://github.com/netlify/primitives/blob/152529d17ca0a8ee850ea90ee1054e1033ab867e/.github/workflows/release-please.yaml#L9-L10