### PR TITLE
fix: drain response body in cache `delete` and `put`

### DIFF
--- a/packages/cache/src/bootstrap/cache.ts
+++ b/packages/cache/src/bootstrap/cache.ts
@@ -83,11 +83,12 @@ export class NetlifyCache implements Cache {
 
     if (context) {
       const resourceURL = extractAndValidateURL(request)
-
-      await fetch(`${context.url}/${toCacheKey(resourceURL)}`, {
+      const response = await fetch(`${context.url}/${toCacheKey(resourceURL)}`, {
         headers: this[getInternalHeaders](context),
         method: 'DELETE',
       })
+
+      await response.text()
     }
 
     return true
@@ -178,6 +179,8 @@ export class NetlifyCache implements Cache {
 
       context.logger?.(`Failed to write to the cache: ${errorMessage}`)
     }
+
+    await cacheResponse.text()
   }
 }
 


### PR DESCRIPTION
The `delete()` and `put()` methods of the Cache API are not draining the response body before resolving. They're also not returning the response (per the spec), which means that consumers can't access the body themselves.

In this PR we read the response body in both methods before resolving.