### PR TITLE
fix: manually tee response body in `fetchWithCache`

### DIFF
--- a/packages/cache/src/cache-headers/cache-headers.ts
+++ b/packages/cache/src/cache-headers/cache-headers.ts
@@ -95,7 +95,7 @@ const getNetlifyVary = (varyOptions?: VaryOptions) => {
   return directives.join(',')
 }
 
-const applyHeaders = (subject: Headers, headersObject: Record<string, string>) => {
+export const applyHeaders = (subject: Headers, headersObject: Record<string, string>) => {
   for (const name in headersObject) {
     if (name === HEADERS.NetlifyCdnCacheControl) {
       subject.set(name, headersObject[name])


### PR DESCRIPTION
There seems to be an issue in undici when using the `Response` constructor to create a new response that has been created from calling `clone()` on another response.

This PR addresses that by changing `fetchWithCache` to manually tee the response body and create two separate responses.

Supersedes https://github.com/netlify/primitives/pull/157.