### PR TITLE
chore: remove npm provenance

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -38,31 +38,31 @@ jobs:
         run: npm run build -ws
 
       # Publishing packages in topological order, as defined in `package.json`.
-      - run: npm publish packages/dev-utils/ --provenance --access=public
+      - run: npm publish packages/dev-utils/ --access=public
         if: ${{ steps.release.outputs['packages/dev-utils--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/blobs/ --provenance --access=public
+      - run: npm publish packages/blobs/ --access=public
         if: ${{ steps.release.outputs['packages/blobs--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/cache/ --provenance --access=public
+      - run: npm publish packages/cache/ --access=public
         if: ${{ steps.release.outputs['packages/cache--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/functions/ --provenance --access=public
+      - run: npm publish packages/functions/ --access=public
         if: ${{ steps.release.outputs['packages/functions--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/redirects/ --provenance --access=public
+      - run: npm publish packages/redirects/ --access=public
         if: ${{ steps.release.outputs['packages/redirects--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/static/ --provenance --access=public
+      - run: npm publish packages/static/ --access=public
         if: ${{ steps.release.outputs['packages/static--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/dev/ --provenance --access=public
+      - run: npm publish packages/dev/ --access=public
         if: ${{ steps.release.outputs['packages/dev--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Publishing to npm started failing since https://github.com/netlify/primitives/pull/151, because you can't publish with provenance when using private repos:

https://github.blog/changelog/2023-07-25-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/

For now, we're removing provenance so that we can continue publishing the packages. We then need to assess how important provenance is for our packages, and based on that we may decide to make this monorepo public.