### PR TITLE
chore: add back npm provenance

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -38,43 +38,43 @@ jobs:
         run: npm run build -ws
 
       # Publishing packages in topological order, as defined in `package.json`.
-      - run: npm publish packages/dev-utils/ --access=public
+      - run: npm publish packages/dev-utils/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/dev-utils--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/runtime-utils/ --access=public
+      - run: npm publish packages/runtime-utils/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/runtime-utils--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}          
-      - run: npm publish packages/blobs/ --access=public
+      - run: npm publish packages/blobs/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/blobs--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/cache/ --access=public
+      - run: npm publish packages/cache/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/cache--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/functions/ --access=public
+      - run: npm publish packages/functions/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/functions--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/redirects/ --access=public
+      - run: npm publish packages/redirects/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/redirects--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/runtime/ --access=public
+      - run: npm publish packages/runtime/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/runtime--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/static/ --access=public
+      - run: npm publish packages/static/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/static--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/dev/ --access=public
+      - run: npm publish packages/dev/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/dev--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish packages/vite-plugin/ --access=public
+      - run: npm publish packages/vite-plugin/ --provenance --access=public
         if: ${{ steps.release.outputs['packages/vite-plugin--release_created'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}          


### PR DESCRIPTION
Reinstates https://github.com/netlify/primitives/pull/151 (temporarily removed in https://github.com/netlify/primitives/pull/159) now that the repository is public.