### PR TITLE
chore: fix repo name in README

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -61,9 +61,9 @@
     "cachestorage"
   ],
   "license": "MIT",
-  "repository": "netlify/cache",
+  "repository": "netlify/primitives",
   "bugs": {
-    "url": "https://github.com/netlify/cache/issues"
+    "url": "https://github.com/netlify/primitives/issues"
   },
   "author": "Netlify Inc.",
   "devDependencies": {


### PR DESCRIPTION
Fixes the failure in https://github.com/netlify/primitives/actions/runs/14886703492/job/41808114525#step:13:74.