### PR TITLE
fix: pin monorepo packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16902,12 +16902,12 @@
       },
       "devDependencies": {
         "@netlify/types": "1.2.0",
-        "@types/node": "^20.17.50",
+        "@types/node": "^20.5.1",
         "node-fetch": "^3.3.1",
-        "semver": "^7.7.2",
+        "semver": "^7.5.3",
         "tmp-promise": "^3.0.3",
         "tsup": "^8.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
@@ -16942,10 +16942,10 @@
         "@netlify/dev-utils": "2.2.0",
         "@netlify/types": "1.2.0",
         "npm-run-all2": "^7.0.2",
-        "semver": "^7.7.2",
+        "semver": "^7.5.3",
         "tmp-promise": "^3.0.3",
         "tsup": "^8.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
@@ -16956,7 +16956,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
-        "@netlify/blobs": "^9.1.2",
+        "@netlify/blobs": "9.1.2",
         "@netlify/config": "^23.0.4",
         "@netlify/dev-utils": "2.2.0",
         "@netlify/functions": "3.1.9",
@@ -16969,7 +16969,7 @@
         "@netlify/types": "1.2.0",
         "tmp-promise": "^3.0.3",
         "tsup": "^8.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
@@ -16994,12 +16994,12 @@
       },
       "devDependencies": {
         "@types/lodash.debounce": "^4.0.9",
-        "@types/node": "^20.17.50",
+        "@types/node": "^20.5.1",
         "@types/parse-gitignore": "^1.0.2",
         "@types/write-file-atomic": "^4.0.3",
         "tmp-promise": "^3.0.3",
         "tsup": "^8.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
@@ -17112,7 +17112,7 @@
       "version": "3.1.9",
       "license": "MIT",
       "dependencies": {
-        "@netlify/blobs": "^9.1.2",
+        "@netlify/blobs": "9.1.2",
         "@netlify/dev-utils": "2.2.0",
         "@netlify/serverless-functions-api": "1.41.2",
         "@netlify/zip-it-and-ship-it": "^12.1.0",
@@ -17127,13 +17127,13 @@
       },
       "devDependencies": {
         "@netlify/eslint-config-node": "^7.0.1",
-        "@types/semver": "^7.7.0",
+        "@types/semver": "^7.5.8",
         "@types/source-map-support": "^0.5.10",
         "npm-run-all2": "^5.0.0",
-        "semver": "^7.7.2",
+        "semver": "^7.6.3",
         "tsd": "^0.31.0",
         "tsup": "^8.0.2",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17246,9 +17246,9 @@
         "@netlify/types": "1.2.0"
       },
       "devDependencies": {
-        "@types/node": "^20.17.50",
+        "@types/node": "^20.5.1",
         "tsup": "^8.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -17259,9 +17259,9 @@
       "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.17.50",
+        "@types/node": "^20.5.1",
         "tsup": "^8.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -17343,10 +17343,10 @@
         "chalk": "^5.4.1"
       },
       "devDependencies": {
-        "@types/node": "^20.17.50",
+        "@types/node": "^20.5.1",
         "tsup": "^8.0.0",
         "vite": "^6.3.4",
-        "vitest": "^3.1.4"
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -53,7 +53,7 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "@netlify/blobs": "^9.1.2",
+    "@netlify/blobs": "9.1.2",
     "@netlify/config": "^23.0.4",
     "@netlify/dev-utils": "2.2.0",
     "@netlify/functions": "3.1.9",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -80,7 +80,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@netlify/blobs": "^9.1.2",
+    "@netlify/blobs": "9.1.2",
     "@netlify/dev-utils": "2.2.0",
     "@netlify/serverless-functions-api": "1.41.2",
     "@netlify/zip-it-and-ship-it": "^12.1.0",


### PR DESCRIPTION
Pins the version of `@netlify/blobs` in the `dev` and `functions` packages.