### PR TITLE
build: fix vitest scripts

### DIFF
--- a/packages/blobs/package.json
+++ b/packages/blobs/package.json
@@ -48,10 +48,10 @@
     "build": "tsup-node",
     "dev": "tsup-node --watch",
     "prepack": "npm run build",
-    "test": "run-s build test:dev",
+    "test": "run-s build test:ci",
     "test:dev": "run-s build test:dev:*",
     "test:ci": "run-s build test:ci:*",
-    "test:dev:vitest": "vitest run",
+    "test:dev:vitest": "vitest",
     "test:dev:vitest:watch": "vitest watch",
     "test:ci:vitest": "vitest run",
     "publint": "npx -y publint --strict"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -47,10 +47,10 @@
     "build": "tsup-node",
     "dev": "tsup-node --watch",
     "prepack": "npm run build",
-    "test": "run-s build test:dev",
+    "test": "run-s build test:ci",
     "test:dev": "run-s build test:dev:*",
     "test:ci": "run-s build test:ci:*",
-    "test:dev:vitest": "vitest run",
+    "test:dev:vitest": "vitest",
     "test:dev:vitest:watch": "vitest watch",
     "test:ci:vitest": "vitest run",
     "publint": "npx -y publint --strict"

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -52,7 +52,7 @@
     "dev": "tsup-node --watch",
     "build": "tsup-node",
     "prepack": "npm run build",
-    "test": "run-s test:dev",
+    "test": "run-s test:ci",
     "test:dev": "run-s build test:dev:*",
     "test:dev:tsd": "tsd",
     "test:dev:vitest": "vitest",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -46,10 +46,10 @@
     "build": "tsup-node",
     "dev": "tsup-node --watch",
     "prepack": "npm run build",
-    "test": "run-s build test:dev",
+    "test": "run-s build test:ci",
     "test:dev": "run-s build test:dev:*",
     "test:ci": "run-s build test:ci:*",
-    "test:dev:vitest": "vitest run",
+    "test:dev:vitest": "vitest",
     "test:dev:vitest:watch": "vitest watch",
     "test:ci:vitest": "vitest run",
     "publint": "npx -y publint --strict"


### PR DESCRIPTION
Most of this monorepo's packages test scripts had consistent behaviour except these few.

This also resulted in the documented `npm run test -ws` hanging because some of the packages' `test` commands were watching for changes.