### PR TITLE
fix: inject env vars even when unlinked

### DIFF
--- a/packages/dev/src/lib/env.ts
+++ b/packages/dev/src/lib/env.ts
@@ -43,7 +43,7 @@ interface InjectEnvironmentVariablesOptions {
   baseVariables: Record<string, EnvironmentVariable>
   envAPI: EnvironmentVariables
   netlifyAPI?: NetlifyAPI
-  siteID: string
+  siteID?: string
 }
 
 export const injectEnvVariables = async ({
@@ -57,7 +57,7 @@ export const injectEnvVariables = async ({
 
   let variables = baseVariables
 
-  if (netlifyAPI && accountSlug) {
+  if (netlifyAPI && siteID && accountSlug) {
     variables = await getEnvelopeEnv({
       accountId: accountSlug,
       api: netlifyAPI,

--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -299,7 +299,7 @@ export class NetlifyDev {
 
     let envVariables: Record<string, InjectedEnvironmentVariable> = {}
 
-    if (this.#features.environmentVariables && siteID) {
+    if (this.#features.environmentVariables) {
       // TODO: Use proper types for this.
       envVariables = await injectEnvVariables({
         accountSlug: config?.siteInfo?.account_slug,


### PR DESCRIPTION
Just like in Netlify CLI, it's just the fetching of env vars for the site via the Netlify API that we want to skip when we aren't linked to a site. The rest (Netlify defaults, `netlify.toml` envs, etc.) should still be injected.

I'll come back and add a test later.