### PR TITLE
feat: improve error handling in edge functions

### DIFF
--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -333,6 +333,7 @@ export class NetlifyDev {
         directories: [this.#config?.config.build.edge_functions].filter(Boolean) as string[],
         env,
         geolocation: mockLocation,
+        logger: this.#logger,
         originServerAddress: serverAddress,
         siteID,
         siteName: config?.siteInfo.name,

--- a/packages/edge-functions/dev/deno/workers/runner.ts
+++ b/packages/edge-functions/dev/deno/workers/runner.ts
@@ -1,14 +1,5 @@
 import type { Message, RunResponseStartMessage, RunResponseChunkMessage, RunResponseEndMessage } from './types.ts'
 
-// The timeout imposed by the edge nodes. It's important to keep this in place
-// as a fallback in case we're unable to patch `fetch` to add our own here.
-// https://github.com/netlify/stargate/blob/b5bc0eeb79bbbad3a8a6f41c7c73f1bcbcb8a9c8/proxy/deno/edge.go#L77
-const UPSTREAM_REQUEST_TIMEOUT = 37_000
-
-// The overall timeout should be at most the limit imposed by the edge nodes
-// minus a buffer that gives us enough time to send back a response.
-const REQUEST_TIMEOUT = UPSTREAM_REQUEST_TIMEOUT - 1_000
-
 const consoleLog = globalThis.console.log
 const fetchRewrites = new Map<string, string>()
 
@@ -36,7 +27,7 @@ self.onmessage = async (e) => {
     const res = await handleRequest(req, functions, {
       fetchRewrites,
       rawLogger: consoleLog,
-      requestTimeout: REQUEST_TIMEOUT,
+      requestTimeout: message.data.timeout,
     })
 
     self.postMessage({

--- a/packages/edge-functions/dev/deno/workers/types.ts
+++ b/packages/edge-functions/dev/deno/workers/types.ts
@@ -32,6 +32,7 @@ export interface RunRequestMessage {
     functions: Record<string, string>
     headers: Record<string, string>
     method: string
+    timeout: number
     url: string
   }
 }


### PR DESCRIPTION
Two separate commits:

- https://github.com/netlify/primitives/commit/3ccb57973496c9930acfaa981885ea40d824778b: Improves the error handling for when we fail to initialise the Deno server
- https://github.com/netlify/primitives/commit/056b12f4bf13fb029fad1cf5a988115d4e737d4b: Moves the invocation timeout to the runner and actually start enforcing it in case the worker doesn't send headers in time