### PR TITLE
fix: pass run options to Deno script as arg

### DIFF
--- a/packages/edge-functions/dev/deno/server.mjs
+++ b/packages/edge-functions/dev/deno/server.mjs
@@ -68,8 +68,6 @@ export const serveLocal = ({ bootstrapURL, denoPort: port, requestTimeout }) => 
   return server.finished
 }
 
-const url = new URL(import.meta.url)
-const rawOptions = url.searchParams.get('options')
-const options = JSON.parse(decodeURIComponent(rawOptions))
+const runOptions = JSON.parse(Deno.args[0])
 
-await serveLocal(options)
+await serveLocal(runOptions)

--- a/packages/edge-functions/dev/node/main.ts
+++ b/packages/edge-functions/dev/node/main.ts
@@ -271,10 +271,10 @@ export class EdgeFunctionsHandler {
       requestTimeout: this.requestTimeout,
     }
     const denoFlags: string[] = ['--allow-scripts', '--quiet', '--no-lock']
-    const script = `import('${pathToFileURL(denoRunPath).toString()}?options=${encodeURIComponent(JSON.stringify(runOptions))}');`
+    const script = `import('${pathToFileURL(denoRunPath).toString()}');`
 
     try {
-      await denoBridge.runInBackground(['eval', ...denoFlags, script], processRef, {
+      await denoBridge.runInBackground(['eval', ...denoFlags, script, JSON.stringify(runOptions)], processRef, {
         env,
         extendEnv: false,
         pipeOutput: true,


### PR DESCRIPTION
I don't know why this works locally but not when pulling the code from the npm package, but it seems that passing parameters to the Deno script via its import URL is causing issues.

This PR changes it so that the run options are passed via `Deno.args`.