### PR TITLE
fix: add guard against query param handling

### DIFF
--- a/packages/dev/src/main.test.ts
+++ b/packages/dev/src/main.test.ts
@@ -265,7 +265,7 @@ describe('Handling requests', () => {
           `export default async () => new Response("Hello from function"); export const config = { path: "/hello" };`,
         )
       const directory = await fixture.create()
-      const req = new Request('https://site.netlify/hello')
+      const req = new Request('https://site.netlify/hello?param1=value1')
       const dev = new NetlifyDev({
         projectRoot: directory,
       })

--- a/packages/functions/dev/main.test.ts
+++ b/packages/functions/dev/main.test.ts
@@ -23,6 +23,7 @@ describe('Functions with the v2 API syntax', () => {
         events.handleEvent(event)
       },
       destPath,
+      geolocation: {},
       projectRoot: directory,
       settings: {},
       timeouts: {},
@@ -86,6 +87,7 @@ describe('Functions with the v2 API syntax', () => {
       accountId: 'account-123',
       config: {},
       destPath,
+      geolocation: {},
       projectRoot: directory,
       settings: {},
       timeouts: {},
@@ -132,6 +134,7 @@ describe('Functions with the v2 API syntax', () => {
         events.handleEvent(event)
       },
       destPath,
+      geolocation: {},
       projectRoot: directory,
       settings: {},
       timeouts: {},

--- a/packages/functions/dev/runtimes/nodejs/lambda.ts
+++ b/packages/functions/dev/runtimes/nodejs/lambda.ts
@@ -36,7 +36,7 @@ export const lambdaEventFromWebRequest = async (request: Request, route?: string
 
   url.searchParams.forEach((value, key) => {
     queryStringParameters[key] = queryStringParameters[key] ? `${queryStringParameters[key]},${value}` : value
-    multiValueQueryStringParameters[key] = [...multiValueQueryStringParameters[key], value]
+    multiValueQueryStringParameters[key] = [...(multiValueQueryStringParameters[key] ?? []), value]
   })
 
   const { headers, multiValueHeaders } = headersObjectFromWebHeaders(request.headers)


### PR DESCRIPTION
Without this check, sending to the functions handler a request with query parameters in the URL would fail.