### PR TITLE
chore: remove not existing files from package.json#files

### DIFF
--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -22,8 +22,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/**/*",
-    "server.d.ts"
+    "dist/**/*"
   ],
   "scripts": {
     "build": "tsup-node",

--- a/packages/edge-functions/package.json
+++ b/packages/edge-functions/package.json
@@ -25,8 +25,7 @@
   "files": [
     "dist/**/*",
     "dist-dev/**/*",
-    "deno/**/*",
-    "server.d.ts"
+    "deno/**/*"
   ],
   "scripts": {
     "build": "tsup-node",

--- a/packages/redirects/package.json
+++ b/packages/redirects/package.json
@@ -10,8 +10,7 @@
   "exports": "./dist/main.js",
   "types": "./dist/main.d.ts",
   "files": [
-    "dist/**/*",
-    "server.d.ts"
+    "dist/**/*"
   ],
   "scripts": {
     "build": "tsup-node",

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -10,8 +10,7 @@
   "exports": "./dist/main.js",
   "types": "./dist/main.d.ts",
   "files": [
-    "dist/**/*",
-    "server.d.ts"
+    "dist/**/*"
   ],
   "scripts": {
     "build": "tsup-node",


### PR DESCRIPTION
Seems like quite a bit of our packages "inhererited"/copied `server.d.ts` in `package.json#files` from https://github.com/netlify/primitives/blob/f4360c955812e7b96dfb1b0f8112d70496488ee2/packages/blobs/package.json#L43-L46

but this file doesn't exist / is not produced in any other package other than `@netlify/blobs`