### PR TITLE
chore: use package specific tsconfig for linting

### DIFF
--- a/packages/edge-functions/tsconfig.json
+++ b/packages/edge-functions/tsconfig.json
@@ -12,5 +12,6 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true
-  }
+  },
+  "include": ["src", "dev"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,5 +20,5 @@
 
     "strict": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "packages/*/src", "packages/edge-functions/dev"]
 }


### PR DESCRIPTION
after some debbuging our eslint config (with `debugLevel: ['typescript', 'typescript-eslint'],` https://typescript-eslint.io/packages/typescript-estree/#api ) I noticed that that eslint is not using package's tsconfig because top-level one is matching everything pretty much first and seems to be picked.

Before (see just base tsconfig in logs):
```
> npx eslint --debug packages/cache/src/fetchwithcache.ts
[...]
  typescript-eslint:typescript-estree:create-program:useProvidedPrograms Retrieving ast for /Users/misiek/dev/pgs-netlify-primitives/packages/cache/src/fetchwithcache.ts from provided program instance(s) +0ms
  typescript-eslint:typescript-estree:parser Detected single-run/CLI usage, creating Program once ahead of time for project: [
  '/users/misiek/dev/pgs-netlify-primitives/tsconfig.base.json',
  '/Users/misiek/dev/pgs-netlify-primitives/tsconfig.base.json'
] +0ms
  typescript-eslint:parser:parser Resolved libs from program: [ 'es2020', 'dom' ] +0ms
  eslint:languages:js Parsing successful: /Users/misiek/dev/pgs-netlify-primitives/packages/cache/src/fetchwithcache.ts +2s
  eslint:languages:js Scope analysis: /Users/misiek/dev/pgs-netlify-primitives/packages/cache/src/fetchwithcache.ts +0ms
  eslint:languages:js Scope analysis successful: /Users/misiek/dev/pgs-netlify-primitives/packages/cache/src/fetchwithcache.ts +0ms
  typescript-eslint:type-utils:predicates Found an "error" any type +0ms
  typescript-eslint:type-utils:predicates Found an "error" any type +1ms
  typescript-eslint:type-utils:predicates Found an "error" any type +1ms
  typescript-eslint:type-utils:predicates Found an "error" any type +0ms
  typescript-eslint:type-utils:predicates Found an "error" any type +0ms
```

After (see that this time `cache/tsconfig.json` is being noted) :
```
> npx eslint --debug packages/cache/src/fetchwithcache.ts
[...]
typescript-eslint:typescript-estree:create-program:useProvidedPrograms Retrieving ast for /Users/misiek/dev/netlify-primitives/packages/cache/src/fetchwithcache.ts from provided program instance(s) +0ms
  typescript-eslint:typescript-estree:parser Detected single-run/CLI usage, creating Program once ahead of time for project: [
  '/users/misiek/dev/netlify-primitives/tsconfig.base.json',
  '/Users/misiek/dev/netlify-primitives/tsconfig.base.json'
] +0ms
  typescript-eslint:typescript-estree:parser Detected single-run/CLI usage, creating Program once ahead of time for project: [
  '/users/misiek/dev/netlify-primitives/packages/blobs/tsconfig.json',
  '/Users/misiek/dev/netlify-primitives/packages/blobs/tsconfig.json'
] +983ms
  typescript-eslint:typescript-estree:parser Detected single-run/CLI usage, creating Program once ahead of time for project: [
  '/users/misiek/dev/netlify-primitives/packages/cache/tsconfig.json',
  '/Users/misiek/dev/netlify-primitives/packages/cache/tsconfig.json'
] +307ms
  typescript-eslint:parser:parser Resolved libs from program: [ 'es2020.full' ] +0ms
  eslint:languages:js Parsing successful: /Users/misiek/dev/netlify-primitives/packages/cache/src/fetchwithcache.ts +2s
  eslint:languages:js Scope analysis: /Users/misiek/dev/netlify-primitives/packages/cache/src/fetchwithcache.ts +0ms
  eslint:languages:js Scope analysis successful: /Users/misiek/dev/netlify-primitives/packages/cache/src/fetchwithcache.ts +0ms
```

Potential alternatives I tried was just reordering the `tsconfig.json` declarations in `project`, but it seems to have no effect and always produce following map:
```
  typescript-eslint:typescript-estree:parseSettings:resolveProjectList parserOptions.project (excluding ignored) matched projects: Map(16) {
  '/users/misiek/dev/pgs-netlify-primitives/tsconfig.base.json' => '/Users/misiek/dev/pgs-netlify-primitives/tsconfig.base.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/blobs/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/blobs/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/cache/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/cache/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/dev/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/dev/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/dev-utils/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/dev-utils/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/edge-functions/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/edge-functions/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/functions/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/functions/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/headers/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/headers/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/images/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/images/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/otel/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/otel/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/redirects/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/redirects/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/runtime/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/runtime/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/runtime-utils/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/runtime-utils/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/static/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/static/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/types/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/types/tsconfig.json',
  '/users/misiek/dev/pgs-netlify-primitives/packages/vite-plugin/tsconfig.json' => '/Users/misiek/dev/pgs-netlify-primitives/packages/vite-plugin/tsconfig.json'
} +0ms
```
And then it attempts to match tsconfig in order of this map until it find satisfying one, and because right now base tsconfig match everything - it's used for everything when linting.

Yet another alternative would be to fully drop top-level base tsconfig and make sure that individual packages tsconfigs include everything they don't currently (most of them only include `src`, so some config files in root of package like `vitest.config.js` or `tsup.config.js` are currently being covered by base config)