### PR TITLE
feat!: add support for conditional writes

### DIFF
--- a/packages/blobs/src/client.ts
+++ b/packages/blobs/src/client.ts
@@ -8,7 +8,7 @@ import { BlobsInternalError } from './util.ts'
 
 export const SIGNED_URL_ACCEPT_HEADER = 'application/json;type=signed-url'
 
-export type Conditions = { ifNotExists?: boolean } | { ifExistsWithEtag?: string }
+export type Conditions = { onlyIfNew?: boolean } | { onlyIfMatch?: string }
 
 interface MakeStoreRequestOptions {
   body?: BlobInput | null
@@ -201,9 +201,9 @@ export class Client {
       headers['cache-control'] = 'max-age=0, stale-while-revalidate=60'
     }
 
-    if ('ifExistsWithEtag' in conditions && conditions.ifExistsWithEtag) {
-      headers['if-match'] = conditions.ifExistsWithEtag
-    } else if ('ifNotExists' in conditions && conditions.ifNotExists) {
+    if ('onlyIfMatch' in conditions && conditions.onlyIfMatch) {
+      headers['if-match'] = conditions.onlyIfMatch
+    } else if ('onlyIfNew' in conditions && conditions.onlyIfNew) {
       headers['if-none-match'] = '*'
     }
 

--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -214,7 +214,7 @@ describe('get', () => {
     })
 
     describe('Conditional writes', () => {
-      test('Returns `modified: false` when `ifNotExists` is true and key exists', async () => {
+      test('Returns `modified: false` when `onlyIfNew` is true and key exists', async () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${apiToken}` },
@@ -235,7 +235,7 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifNotExists: true,
+          onlyIfNew: true,
         })
 
         expect(result.modified).toBe(false)
@@ -243,7 +243,7 @@ describe('get', () => {
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Returns `modified: true` when `ifNotExists` is true and key does not exist', async () => {
+      test('Returns `modified: true` when `onlyIfNew` is true and key does not exist', async () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${apiToken}` },
@@ -264,7 +264,7 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifNotExists: true,
+          onlyIfNew: true,
         })
 
         expect(result.modified).toBe(true)
@@ -272,7 +272,7 @@ describe('get', () => {
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Returns `modified: false` when `ifExistsWithEtag` does not match', async () => {
+      test('Returns `modified: false` when `onlyIfMatch` does not match', async () => {
         const etag = 'etag-123'
         const mockStore = new MockFetch()
           .put({
@@ -294,7 +294,7 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifExistsWithEtag: etag,
+          onlyIfMatch: etag,
         })
 
         expect(result.modified).toBe(false)
@@ -302,7 +302,7 @@ describe('get', () => {
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Returns `modified: true` when `ifExistsWithEtag` matches', async () => {
+      test('Returns `modified: true` when `onlyIfMatch` matches', async () => {
         const etag = 'etag-123'
         const mockStore = new MockFetch()
           .put({
@@ -324,7 +324,7 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifExistsWithEtag: etag,
+          onlyIfMatch: etag,
         })
 
         expect(result.modified).toBe(true)
@@ -410,7 +410,7 @@ describe('get', () => {
     })
 
     describe('Conditional writes', () => {
-      test('Returns `modified: false` when `ifNotExists` is true and key exists', async () => {
+      test('Returns `modified: false` when `onlyIfNew` is true and key exists', async () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
@@ -427,14 +427,14 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifNotExists: true,
+          onlyIfNew: true,
         })
 
         expect(result.modified).toBe(false)
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Returns `modified: true` when `ifNotExists` is true and key does not exist', async () => {
+      test('Returns `modified: true` when `onlyIfNew` is true and key does not exist', async () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
@@ -451,7 +451,7 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifNotExists: true,
+          onlyIfNew: true,
         })
 
         expect(result.modified).toBe(true)
@@ -459,7 +459,7 @@ describe('get', () => {
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Returns `modified: false` when `ifExistsWithEtag` does not match', async () => {
+      test('Returns `modified: false` when `onlyIfMatch` does not match', async () => {
         const etag = 'etag-123'
         const mockStore = new MockFetch()
           .put({
@@ -477,14 +477,14 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifExistsWithEtag: etag,
+          onlyIfMatch: etag,
         })
 
         expect(result.modified).toBe(false)
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Returns `modified: true` when `ifExistsWithEtag` matches', async () => {
+      test('Returns `modified: true` when `onlyIfMatch` matches', async () => {
         const etag = 'etag-123'
         const mockStore = new MockFetch()
           .put({
@@ -502,7 +502,7 @@ describe('get', () => {
         })
 
         const result = await blobs.set(key, value, {
-          ifExistsWithEtag: etag,
+          onlyIfMatch: etag,
         })
 
         expect(result.modified).toBe(true)
@@ -510,7 +510,7 @@ describe('get', () => {
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
-      test('Throws an error when both `ifNotExists` and `ifExistsWithEtag` are provided', async () => {
+      test('Throws an error when both `onlyIfNew` and `onlyIfMatch` are provided', async () => {
         const blobs = getStore({
           name: 'production',
           token: apiToken,
@@ -519,17 +519,17 @@ describe('get', () => {
 
         await expect(
           blobs.set(key, value, {
-            ifNotExists: true,
+            onlyIfNew: true,
 
             // @ts-expect-error Testing runtime validation
-            ifExistsWithEtag: '"123"',
+            onlyIfMatch: '"123"',
           }),
         ).rejects.toThrow(
-          `The 'ifExistsWithEtag' and 'ifNotExists' options are mutually exclusive. Using 'ifExistsWithEtag' will make the write succeed only if there is an entry for the key with the given content, while 'ifNotExists' will make the write succeed only if there is no entry for the key.`,
+          `The 'onlyIfMatch' and 'onlyIfNew' options are mutually exclusive. Using 'onlyIfMatch' will make the write succeed only if there is an entry for the key with the given content, while 'onlyIfNew' will make the write succeed only if there is no entry for the key.`,
         )
       })
 
-      test('Throws an error when `ifExistsWithEtag` is not a string', async () => {
+      test('Throws an error when `onlyIfMatch` is not a string', async () => {
         const blobs = getStore({
           name: 'production',
           token: apiToken,
@@ -539,12 +539,12 @@ describe('get', () => {
         await expect(
           blobs.set(key, value, {
             // @ts-expect-error Testing runtime validation
-            ifExistsWithEtag: 123,
+            onlyIfMatch: 123,
           }),
-        ).rejects.toThrow(`The 'ifExistsWithEtag' property expects a string representing an ETag.`)
+        ).rejects.toThrow(`The 'onlyIfMatch' property expects a string representing an ETag.`)
       })
 
-      test('Throws an error when `ifNotExists` is not a boolean', async () => {
+      test('Throws an error when `onlyIfNew` is not a boolean', async () => {
         const blobs = getStore({
           name: 'production',
           token: apiToken,
@@ -554,10 +554,10 @@ describe('get', () => {
         await expect(
           blobs.set(key, value, {
             // @ts-expect-error Testing runtime validation
-            ifNotExists: 'yes',
+            onlyIfNew: 'yes',
           }),
         ).rejects.toThrow(
-          `The 'ifNotExists' property expects a boolean indicating whether the write should fail if an entry for the key already exists.`,
+          `The 'onlyIfNew' property expects a boolean indicating whether the write should fail if an entry for the key already exists.`,
         )
       })
     })

--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -223,7 +223,7 @@ describe('get', () => {
           })
           .put({
             headers: { 'if-none-match': '*' },
-            response: new Response(null, { status: 304 }),
+            response: new Response(null, { status: 412 }),
             url: signedURL,
           })
           .inject()
@@ -252,7 +252,7 @@ describe('get', () => {
           })
           .put({
             headers: { 'if-none-match': '*' },
-            response: new Response(null, { status: 412, headers: { etag: '"123"' } }),
+            response: new Response(null, { status: 201, headers: { etag: '"123"' } }),
             url: signedURL,
           })
           .inject()
@@ -282,7 +282,7 @@ describe('get', () => {
           })
           .put({
             headers: { 'if-match': etag },
-            response: new Response(null, { status: 304 }),
+            response: new Response(null, { status: 412 }),
             url: signedURL,
           })
           .inject()
@@ -414,7 +414,7 @@ describe('get', () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
-            response: new Response(null, { status: 304 }),
+            response: new Response(null, { status: 412 }),
             url: `${edgeURL}/${siteID}/site:production/${key}`,
           })
           .inject()
@@ -438,7 +438,7 @@ describe('get', () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
-            response: new Response(null, { status: 200, headers: { etag: '"123"' } }),
+            response: new Response(null, { status: 201, headers: { etag: '"123"' } }),
             url: `${edgeURL}/${siteID}/site:production/${key}`,
           })
           .inject()
@@ -464,7 +464,7 @@ describe('get', () => {
         const mockStore = new MockFetch()
           .put({
             headers: { authorization: `Bearer ${edgeToken}`, 'if-match': etag },
-            response: new Response(null, { status: 304 }),
+            response: new Response(null, { status: 412 }),
             url: `${edgeURL}/${siteID}/site:production/${key}`,
           })
           .inject()

--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -132,7 +132,7 @@ describe('get', () => {
         siteID,
       })
 
-      expect(async () => await blobs.get(key)).rejects.toThrowError(
+      await expect(async () => await blobs.get(key)).rejects.toThrowError(
         `Netlify Blobs has generated an internal error (401 status code, ID: ${mockRequestID})`,
       )
       expect(mockStore.fulfilled).toBeTruthy()
@@ -212,6 +212,126 @@ describe('get', () => {
 
       expect(mockStore.fulfilled).toBeTruthy()
     })
+
+    describe('Conditional writes', () => {
+      test('Returns `modified: false` when `ifNotExists` is true and key exists', async () => {
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${apiToken}` },
+            response: new Response(JSON.stringify({ url: signedURL })),
+            url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+          })
+          .put({
+            headers: { 'if-none-match': '*' },
+            response: new Response(null, { status: 304 }),
+            url: signedURL,
+          })
+          .inject()
+
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifNotExists: true,
+        })
+
+        expect(result.modified).toBe(false)
+        expect(result.etag).toBeUndefined()
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Returns `modified: true` when `ifNotExists` is true and key does not exist', async () => {
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${apiToken}` },
+            response: new Response(JSON.stringify({ url: signedURL })),
+            url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+          })
+          .put({
+            headers: { 'if-none-match': '*' },
+            response: new Response(null, { status: 412, headers: { etag: '"123"' } }),
+            url: signedURL,
+          })
+          .inject()
+
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifNotExists: true,
+        })
+
+        expect(result.modified).toBe(true)
+        expect(result.etag).toBe('"123"')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Returns `modified: false` when `ifExistsWithEtag` does not match', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${apiToken}` },
+            response: new Response(JSON.stringify({ url: signedURL })),
+            url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+          })
+          .put({
+            headers: { 'if-match': etag },
+            response: new Response(null, { status: 304 }),
+            url: signedURL,
+          })
+          .inject()
+
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifExistsWithEtag: etag,
+        })
+
+        expect(result.modified).toBe(false)
+        expect(result.etag).toBeUndefined()
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Returns `modified: true` when `ifExistsWithEtag` matches', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${apiToken}` },
+            response: new Response(JSON.stringify({ url: signedURL })),
+            url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+          })
+          .put({
+            headers: { 'if-match': etag },
+            response: new Response(null, { status: 200, headers: { etag: '"123"' } }),
+            url: signedURL,
+          })
+          .inject()
+
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifExistsWithEtag: etag,
+        })
+
+        expect(result.modified).toBe(true)
+        expect(result.etag).toBe('"123"')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+    })
   })
 
   describe('With edge credentials', () => {
@@ -287,6 +407,159 @@ describe('get', () => {
       )
 
       expect(mockStore.fulfilled).toBeTruthy()
+    })
+
+    describe('Conditional writes', () => {
+      test('Returns `modified: false` when `ifNotExists` is true and key exists', async () => {
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
+            response: new Response(null, { status: 304 }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+          .inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifNotExists: true,
+        })
+
+        expect(result.modified).toBe(false)
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Returns `modified: true` when `ifNotExists` is true and key does not exist', async () => {
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
+            response: new Response(null, { status: 200, headers: { etag: '"123"' } }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+          .inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifNotExists: true,
+        })
+
+        expect(result.modified).toBe(true)
+        expect(result.etag).toBe('"123"')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Returns `modified: false` when `ifExistsWithEtag` does not match', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-match': etag },
+            response: new Response(null, { status: 304 }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+          .inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifExistsWithEtag: etag,
+        })
+
+        expect(result.modified).toBe(false)
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Returns `modified: true` when `ifExistsWithEtag` matches', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-match': etag },
+            response: new Response(null, { status: 200, headers: { etag: '"123"' } }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+          .inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = await blobs.set(key, value, {
+          ifExistsWithEtag: etag,
+        })
+
+        expect(result.modified).toBe(true)
+        expect(result.etag).toBe('"123"')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Throws an error when both `ifNotExists` and `ifExistsWithEtag` are provided', async () => {
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        await expect(
+          blobs.set(key, value, {
+            ifNotExists: true,
+
+            // @ts-expect-error Testing runtime validation
+            ifExistsWithEtag: '"123"',
+          }),
+        ).rejects.toThrow(
+          `The 'ifExistsWithEtag' and 'ifNotExists' options are mutually exclusive. Using 'ifExistsWithEtag' will make the write succeed only if there is an entry for the key with the given content, while 'ifNotExists' will make the write succeed only if there is no entry for the key.`,
+        )
+      })
+
+      test('Throws an error when `ifExistsWithEtag` is not a string', async () => {
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        await expect(
+          blobs.set(key, value, {
+            // @ts-expect-error Testing runtime validation
+            ifExistsWithEtag: 123,
+          }),
+        ).rejects.toThrow(`The 'ifExistsWithEtag' property expects a string representing an ETag.`)
+      })
+
+      test('Throws an error when `ifNotExists` is not a boolean', async () => {
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        await expect(
+          blobs.set(key, value, {
+            // @ts-expect-error Testing runtime validation
+            ifNotExists: 'yes',
+          }),
+        ).rejects.toThrow(
+          `The 'ifNotExists' property expects a boolean indicating whether the write should fail if an entry for the key already exists.`,
+        )
+      })
     })
 
     describe('Loads credentials from the environment', () => {
@@ -804,7 +1077,7 @@ describe('set', () => {
         siteID,
       })
 
-      expect(async () => await blobs.set(key, 'value')).rejects.toThrowError(
+      await expect(async () => await blobs.set(key, 'value')).rejects.toThrowError(
         `Netlify Blobs has generated an internal error (401 status code)`,
       )
       expect(mockStore.fulfilled).toBeTruthy()
@@ -819,11 +1092,11 @@ describe('set', () => {
         siteID,
       })
 
-      expect(async () => await blobs.set('', 'value')).rejects.toThrowError('Blob key must not be empty.')
-      expect(async () => await blobs.set('/key', 'value')).rejects.toThrowError(
+      await expect(async () => await blobs.set('', 'value')).rejects.toThrowError('Blob key must not be empty.')
+      await expect(async () => await blobs.set('/key', 'value')).rejects.toThrowError(
         'Blob key must not start with forward slash (/).',
       )
-      expect(async () => await blobs.set('a'.repeat(801), 'value')).rejects.toThrowError(
+      await expect(async () => await blobs.set('a'.repeat(801), 'value')).rejects.toThrowError(
         'Blob key must be a sequence of Unicode characters whose UTF-8 encoding is at most 600 bytes long.',
       )
     })
@@ -1076,7 +1349,7 @@ describe('setJSON', () => {
         siteID,
       })
 
-      expect(async () => await blobs.setJSON(key, { value }, { metadata })).rejects.toThrowError(
+      await expect(async () => await blobs.setJSON(key, { value }, { metadata })).rejects.toThrowError(
         'Metadata object exceeds the maximum size',
       )
     })

--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -10,7 +10,7 @@ export const LEGACY_STORE_INTERNAL_PREFIX = 'netlify-internal/legacy-namespace/'
 export const SITE_STORE_PREFIX = 'site:'
 
 const STATUS_OK = 200
-const STATUS_NOT_MODIFIED = 304
+const STATUS_PRE_CONDITION_FAILED = 412
 
 interface BaseStoreOptions {
   client: Client
@@ -340,7 +340,7 @@ export class Store {
     const etag = res.headers.get('etag') ?? ''
 
     if (conditions) {
-      return res.status === STATUS_NOT_MODIFIED ? { modified: false } : { etag, modified: true }
+      return res.status === STATUS_PRE_CONDITION_FAILED ? { modified: false } : { etag, modified: true }
     }
 
     if (res.status === STATUS_OK) {
@@ -374,7 +374,7 @@ export class Store {
     const etag = res.headers.get('etag') ?? ''
 
     if (conditions) {
-      return res.status === STATUS_NOT_MODIFIED ? { modified: false } : { etag, modified: true }
+      return res.status === STATUS_PRE_CONDITION_FAILED ? { modified: false } : { etag, modified: true }
     }
 
     if (res.status === STATUS_OK) {

--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -67,14 +67,14 @@ interface BaseSetOptions {
 }
 
 type CreateOnlyOptions = {
-  ifExistsWithEtag?: never
+  onlyIfMatch?: never
 
   /**
    * If true, the operation will only succeed if the key does not already exist
    * in the store. If the key exists, the operation will return with
    * `modified: false`.
    */
-  ifNotExists?: boolean
+  onlyIfNew?: boolean
 }
 
 type UpdateOnlyOptions = {
@@ -83,9 +83,9 @@ type UpdateOnlyOptions = {
    * in the store and its current ETag matches this value. If it doesn't match,
    * the operation will return with `modified: false`.
    */
-  ifExistsWithEtag?: string
+  onlyIfMatch?: string
 
-  ifNotExists?: never
+  onlyIfNew?: never
 }
 
 export type SetOptions = BaseSetOptions & (CreateOnlyOptions | UpdateOnlyOptions)
@@ -399,31 +399,31 @@ export class Store {
   }
 
   private static getConditions(options: SetOptions): Conditions | undefined {
-    if ('ifExistsWithEtag' in options && 'ifNotExists' in options) {
+    if ('onlyIfMatch' in options && 'onlyIfNew' in options) {
       throw new Error(
-        `The 'ifExistsWithEtag' and 'ifNotExists' options are mutually exclusive. Using 'ifExistsWithEtag' will make the write succeed only if there is an entry for the key with the given content, while 'ifNotExists' will make the write succeed only if there is no entry for the key.`,
+        `The 'onlyIfMatch' and 'onlyIfNew' options are mutually exclusive. Using 'onlyIfMatch' will make the write succeed only if there is an entry for the key with the given content, while 'onlyIfNew' will make the write succeed only if there is no entry for the key.`,
       )
     }
 
-    if ('ifExistsWithEtag' in options && options.ifExistsWithEtag) {
-      if (typeof options.ifExistsWithEtag !== 'string') {
-        throw new Error(`The 'ifExistsWithEtag' property expects a string representing an ETag.`)
+    if ('onlyIfMatch' in options && options.onlyIfMatch) {
+      if (typeof options.onlyIfMatch !== 'string') {
+        throw new Error(`The 'onlyIfMatch' property expects a string representing an ETag.`)
       }
 
       return {
-        ifExistsWithEtag: options.ifExistsWithEtag,
+        onlyIfMatch: options.onlyIfMatch,
       }
     }
 
-    if ('ifNotExists' in options && options.ifNotExists) {
-      if (typeof options.ifNotExists !== 'boolean') {
+    if ('onlyIfNew' in options && options.onlyIfNew) {
+      if (typeof options.onlyIfNew !== 'boolean') {
         throw new Error(
-          `The 'ifNotExists' property expects a boolean indicating whether the write should fail if an entry for the key already exists.`,
+          `The 'onlyIfNew' property expects a boolean indicating whether the write should fail if an entry for the key already exists.`,
         )
       }
 
       return {
-        ifNotExists: true,
+        onlyIfNew: true,
       }
     }
   }

--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -93,7 +93,7 @@ export type SetOptions = BaseSetOptions & (CreateOnlyOptions | UpdateOnlyOptions
 export type WriteResult = {
   /**
    * The ETag of the entry after the write operation. It's only present if the
-   * operatio actually resulted in a modified entry.
+   * operation actually resulted in a modified entry.
    */
   etag?: string
 


### PR DESCRIPTION
Adds support for conditional writes to Netlify Blobs by introducing two new options in the `set` and `setJSON` methods:

- `onlyIfNew` (boolean): When set, the write succeeds only if there isn't already an entry with the given key
- `onlyIfMatch` (string): When set, the write succeeds only if there is already an entry with the given key and with an ETag matching this value

By default, `set` and `setJSON` are upsert operations, which means that they will update any existing entry with the new value if one exists, or otherwise create a new one. The new options make it possible to customise that behaviour.

## `onlyIfNew`

`onlyIfNew` lets you perform a create-only operation, making `set` and `setJSON` a no-op if the key already exists.

**✅ Atomic operation**

```ts
const store = getStore("countries")

// Store information about Jane's country if we don't already have it.
const { modified } = await store.set("jane", "Spain", { onlyIfNew: true })

if (modified) {
  console.log("Saved!")
} else {
  console.log("We already had it!")
}
```

This is an atomic operation, which previously required two separate steps, making it prone to [TOCTOU bugs](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use).

**❌ Two-step operation**

```ts
const store = getStore("countries")

const existingEntry = await store.getMetadata("jane")

if (existingEntry) {
  console.log("We already had it!")
} else {
  await store.set("jane", "Spain")

  console.log("Saved!")
}
```

## `onlyIfMatch`

`onlyIfMatch` lets you perform an update-only operation, making `set` and `setJSON` a no-op unless the key already exists and the entry has an ETag matching the given value.

**✅ Atomic operation**

```ts
const store = getStore("users")

// `myLocalCache` is a stub for a local cache implementation you might implement.
const { data, etag } = myLocalCache.get("jane")

const updatedData = {
  ...data,
  lastSeen: Date.now()
}

// Update Jane's information only if it hasn't changed since we cached it.
const { modified } = await store.setJSON("jane", updatedData, { onlyIfMatch: etag })

if (modified) {
  console.log("Saved!")
} else {
  console.log("Cached data is stale. Someone else must've updated the data!")
}
```

This is an atomic operation, which previously required two separate steps, making it prone to [TOCTOU bugs](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use).

**❌ Two-step operation**

```ts
const store = getStore("users")

// `myLocalCache` is a stub for a local cache implementation you might implement.
const { data, etag } = myLocalCache.get("jane")

const existingEntry = await store.getMetadata("jane")

if (existingEntry?.etag === etag) {
  const updatedData = {
    ...data,
    lastSeen: Date.now()
  }

  await store.setJSON("jane", updatedData)

  console.log("Saved!")
} else {
  console.log("Cached data is stale. Someone else must've updated the data!")
}
```

## ⚠️ Breaking changes

The `set` and `setJSON` methods now return a `Promise` that resolves with an object with the following properties:

- `modified` (boolean): Whether the operation has actually modified an entry
- `etag` (string): The etag of the entry, f the operation has actually modified an entry

Previously, these methods returned a `Promise` that resolved with `undefined`.