### PR TITLE
feat: add `serverAddress` to request handler

### DIFF
--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -440,6 +440,8 @@ export class NetlifyDev {
       this.#cleanupJobs.push(() => passthroughServer.stop())
 
       serverAddress = await passthroughServer.start()
+
+      this.#server = serverAddress
     }
 
     let envVariables: Record<string, InjectedEnvironmentVariable> = {}

--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -83,12 +83,6 @@ export interface Features {
   }
 
   /**
-   * If your local development setup has its own HTTP server (e.g. Vite), set
-   * its address here.
-   */
-  serverAddress?: string | null
-
-  /**
    * Configuration options for serving static files.
    */
   staticFiles?: {
@@ -107,6 +101,12 @@ interface NetlifyDevOptions extends Features {
   apiToken?: string
   logger?: Logger
   projectRoot?: string
+
+  /**
+   * If your local development setup has its own HTTP server (e.g. Vite), set
+   * its address here.
+   */
+  serverAddress?: string | null
 }
 
 const notFoundHandler = async () => new Response('Not found', { status: 404 })

--- a/packages/edge-functions/dev/node/main.test.ts
+++ b/packages/edge-functions/dev/node/main.test.ts
@@ -64,7 +64,6 @@ describe('`EdgeFunctionsHandler`', () => {
       },
       geolocation,
       logger: console,
-      originServerAddress: serverAddress,
       siteID: '123',
       siteName: 'test',
     })
@@ -75,7 +74,7 @@ describe('`EdgeFunctionsHandler`', () => {
     const match = await handler.match(req)
     expect(match).toBeTruthy()
 
-    const res = await match?.handle(req)
+    const res = await match?.handle(req, serverAddress)
 
     expect(await res?.json()).toStrictEqual({
       env: { VAR_1: 'value1', VAR_2: 'value2' },
@@ -126,7 +125,6 @@ describe('`EdgeFunctionsHandler`', () => {
       },
       geolocation,
       logger: console,
-      originServerAddress: serverAddress,
       siteID: '123',
       siteName: 'test',
     })
@@ -137,7 +135,7 @@ describe('`EdgeFunctionsHandler`', () => {
     const match = await handler.match(req)
     expect(match).toBeTruthy()
 
-    const res = await match?.handle(req)
+    const res = await match?.handle(req, serverAddress)
 
     expect(await res?.text()).toStrictEqual('FROM ORIGIN')
 
@@ -179,7 +177,6 @@ describe('`EdgeFunctionsHandler`', () => {
       },
       geolocation,
       logger: console,
-      originServerAddress: serverAddress,
       siteID: '123',
       siteName: 'test',
     })
@@ -190,7 +187,7 @@ describe('`EdgeFunctionsHandler`', () => {
     const match = await handler.match(req)
     expect(match).toBeTruthy()
 
-    const res = await match?.handle(req)
+    const res = await match?.handle(req, serverAddress)
 
     expect(await res?.json()).toStrictEqual({
       slug: 'hello-world',
@@ -223,7 +220,6 @@ describe('`EdgeFunctionsHandler`', () => {
       geolocation,
       logger: console,
       requestTimeout: 1_000,
-      originServerAddress: serverAddress,
       siteID: '123',
       siteName: 'test',
     })
@@ -234,7 +230,7 @@ describe('`EdgeFunctionsHandler`', () => {
     const match = await handler.match(req)
     expect(match).toBeTruthy()
 
-    const res = await match?.handle(req)
+    const res = await match?.handle(req, serverAddress)
 
     expect(res?.status).toBe(500)
     expect(await res?.text()).toContain('Failed to parse edge function `unparseable`')
@@ -269,7 +265,6 @@ describe('`EdgeFunctionsHandler`', () => {
       geolocation,
       logger: console,
       requestTimeout: 1_000,
-      originServerAddress: serverAddress,
       siteID: '123',
       siteName: 'test',
     })
@@ -280,7 +275,7 @@ describe('`EdgeFunctionsHandler`', () => {
     const match = await handler.match(req)
     expect(match).toBeTruthy()
 
-    const res = await match?.handle(req)
+    const res = await match?.handle(req, serverAddress)
 
     expect(res?.status).toBe(500)
     expect(await res?.text()).toContain('An edge function took too long to produce a response')

--- a/packages/edge-functions/dev/node/main.ts
+++ b/packages/edge-functions/dev/node/main.ts
@@ -23,7 +23,6 @@ interface EdgeFunctionsHandlerOptions {
   env: Record<string, string>
   geolocation: Geolocation
   logger: Logger
-  originServerAddress: string
   requestTimeout?: number
   siteID?: string
   siteName?: string
@@ -52,7 +51,6 @@ export class EdgeFunctionsHandler {
   private initialization: ReturnType<typeof this.initialize>
   private initialized: boolean
   private logger: Logger
-  private originServerAddress: string
   private requestTimeout: number
   private siteID?: string
   private siteName?: string
@@ -67,7 +65,6 @@ export class EdgeFunctionsHandler {
     })
     this.initialized = false
     this.logger = options.logger
-    this.originServerAddress = options.originServerAddress
     this.requestTimeout = options.requestTimeout ?? REQUEST_TIMEOUT
     this.siteID = options.siteID
     this.siteName = options.siteName
@@ -211,8 +208,8 @@ export class EdgeFunctionsHandler {
     }
 
     return {
-      handle: async (request: Request) => {
-        const originURL = new URL(this.originServerAddress)
+      handle: async (request: Request, originServerAddress: string) => {
+        const originURL = new URL(originServerAddress)
 
         const url = new URL(request.url)
         url.hostname = LOCAL_HOST
@@ -236,7 +233,7 @@ export class EdgeFunctionsHandler {
         const site = {
           id: this.siteID,
           name: this.siteName,
-          url: this.originServerAddress,
+          url: originServerAddress,
         }
 
         request.headers.set(headers.Site, base64Encode(site))

--- a/packages/images/src/main.test.ts
+++ b/packages/images/src/main.test.ts
@@ -42,7 +42,6 @@ describe('`ImageHandler`', () => {
       test('matches on `/.netlify/images', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress: 'http://localhost:5173',
         })
 
         const url = new URL('/.netlify/images', 'https://netlify.com')
@@ -52,7 +51,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle('http://localhost:5173')
 
         expect(response.ok).toBe(true)
         expect(response).toMatchObject(mockedIpxResponse)
@@ -61,7 +60,6 @@ describe('`ImageHandler`', () => {
       test('matches on `/.netlify/images/', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress: 'http://localhost:5173',
         })
 
         const url = new URL('/.netlify/images/', 'https://netlify.com')
@@ -71,7 +69,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle('http://localhost:5173')
 
         expect(response.ok).toBe(true)
         expect(response).toMatchObject(mockedIpxResponse)
@@ -95,7 +93,6 @@ describe('`ImageHandler`', () => {
       test('allows GET requests', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress: 'http://localhost:5173',
         })
 
         const url = new URL('/.netlify/images', 'https://netlify.com')
@@ -105,7 +102,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle('http://localhost:5173')
 
         expect(response.ok).toBe(true)
         expect(response).toMatchObject(mockedIpxResponse)
@@ -123,7 +120,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle('http://localhost:5173')
 
         expect(response.ok).toBe(false)
         expect(await response.text()).toBe('Method Not Allowed')
@@ -164,7 +161,6 @@ describe('`ImageHandler`', () => {
       test('preserves original width if width param is not used', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress,
         })
 
         const url = new URL('/.netlify/images', originServerAddress)
@@ -174,7 +170,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle(originServerAddress)
 
         expect(response.ok).toBe(true)
 
@@ -186,7 +182,6 @@ describe('`ImageHandler`', () => {
       test('resizes image to specified width preserving aspect ratio', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress,
         })
 
         const requestedWidth = 200
@@ -199,7 +194,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle(originServerAddress)
 
         expect(response.ok).toBe(true)
 
@@ -212,7 +207,6 @@ describe('`ImageHandler`', () => {
       test('resizes image to specified height preserving aspect ratio', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress,
         })
 
         const requestedHeight = 200
@@ -225,7 +219,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle(originServerAddress)
 
         expect(response.ok).toBe(true)
 
@@ -238,7 +232,6 @@ describe('`ImageHandler`', () => {
       test('resizes image to specified width and height ignoring original aspect ratio', async () => {
         const imageHandler = new ImageHandler({
           logger: createMockLogger(),
-          originServerAddress,
         })
 
         const requestedWidth = 200
@@ -253,7 +246,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle(originServerAddress)
 
         expect(response.ok).toBe(true)
 
@@ -308,7 +301,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle('https://example.netlify')
 
         expect(response.ok).toBe(true)
 
@@ -334,7 +327,7 @@ describe('`ImageHandler`', () => {
 
         expect(match).toBeDefined()
 
-        const response = await match!.handle()
+        const response = await match!.handle('https://example.netlify')
 
         expect(response.status).toBe(403)
         expect(await response.text()).toBe('Forbidden: Remote image URL not allowed')

--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -26,7 +26,6 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
     name: 'vite-plugin-netlify',
     async configureServer(viteDevServer) {
       const logger = createLoggerFromViteLogger(viteDevServer.config.logger)
-      const { port } = viteDevServer.config.server
       const { blobs, edgeFunctions, functions, middleware = true, redirects, staticFiles } = options
       const netlifyDev = new NetlifyDev({
         blobs,
@@ -34,7 +33,7 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
         functions,
         logger,
         redirects,
-        serverAddress: `http://localhost:${port}`,
+        serverAddress: null,
         staticFiles: {
           ...staticFiles,
           directories: [viteDevServer.config.root, viteDevServer.config.publicDir],
@@ -52,6 +51,7 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
             headersCollector: (key, value) => {
               headers[key] = value
             },
+            serverAddress: `http://localhost:${nodeReq.socket.localPort}`,
           })
 
           const isStaticFile = result?.type === 'static'
@@ -69,7 +69,6 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
 
           next()
         })
-        logger.log(`Middleware loaded. Emulating features: ${netlifyDev.getEnabledFeatures().join(', ')}.`)
       }
 
       if (!netlifyDev.siteIsLinked) {

--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -69,6 +69,7 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
 
           next()
         })
+        logger.log(`Middleware loaded. Emulating features: ${netlifyDev.getEnabledFeatures().join(', ')}.`)
       }
 
       if (!netlifyDev.siteIsLinked) {


### PR DESCRIPTION
Currently, `NetlifyDev` accepts a `serverAddress` option in the constructor. When used in the Vite plugin, this property needs to match the address of the Vite server. This is a problem in some Vite-based frameworks (like Astro), because when we initialise the plugin, the server isn't running yet, so we don't know what port it uses.

With this PR, we're able to defer the definition of `serverAddress` to the `handle` method. At that point, we know for a fact that the Vite server is already running, so we grab the port and set it on the `handle` options.

I have kept the `serverAddress` option in the constructor for backwards-compatibility; if both are supplied, the one in `handle` takes precedence.