### PR TITLE
fix(deps): move tmp-promise to prod deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11110,6 +11110,7 @@
         "lodash.debounce": "^4.0.8",
         "parse-gitignore": "^2.0.0",
         "semver": "^7.7.2",
+        "tmp-promise": "^3.0.3",
         "uuid": "^11.1.0",
         "write-file-atomic": "^5.0.1"
       },
@@ -11120,7 +11121,6 @@
         "@types/parse-gitignore": "^1.0.2",
         "@types/write-file-atomic": "^4.0.3",
         "execa": "^8.0.1",
-        "tmp-promise": "^3.0.3",
         "tsup": "^8.0.0",
         "vitest": "^3.0.0"
       },

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -47,7 +47,6 @@
     "@types/parse-gitignore": "^1.0.2",
     "@types/write-file-atomic": "^4.0.3",
     "execa": "^8.0.1",
-    "tmp-promise": "^3.0.3",
     "tsup": "^8.0.0",
     "vitest": "^3.0.0"
   },
@@ -64,6 +63,7 @@
     "lodash.debounce": "^4.0.8",
     "parse-gitignore": "^2.0.0",
     "semver": "^7.7.2",
+    "tmp-promise": "^3.0.3",
     "uuid": "^11.1.0",
     "write-file-atomic": "^5.0.1"
   }


### PR DESCRIPTION
It's used in an exported file.

💭 I knew it was smelly that `@netlify/dev-utils` [includes test utils as well](https://github.com/netlify/primitives/tree/98d5f969c953c7624d7e84b8db8db5a43aee4ce2/packages/dev-utils/src/test).

💭 I would've thought publint was supposed to catch this... 👀.