### PR TITLE
fix: apply fixes required for Vite plugin in Astro 

### DIFF
--- a/packages/blobs/src/server.ts
+++ b/packages/blobs/src/server.ts
@@ -317,7 +317,7 @@ export class BlobsServer {
       // happen if multiple clients try to write to the same key at the same
       // time. To prevent this, we write to a temporary file first and then
       // atomically move it to its final destination.
-      const tempPath = join(dirname(dataPath), '.' + Math.random().toString())
+      const tempPath = join(dirname(dataPath), `.${Math.random().toString().slice(2)}`)
       const body = await req.arrayBuffer()
       await fs.mkdir(dirname(dataPath), { recursive: true })
       await fs.writeFile(tempPath, Buffer.from(body))

--- a/packages/blobs/src/server.ts
+++ b/packages/blobs/src/server.ts
@@ -1,6 +1,5 @@
 import { createHmac } from 'node:crypto'
 import { createReadStream, promises as fs } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 
 import { HTTPServer } from '@netlify/dev-utils'
@@ -318,10 +317,10 @@ export class BlobsServer {
       // happen if multiple clients try to write to the same key at the same
       // time. To prevent this, we write to a temporary file first and then
       // atomically move it to its final destination.
-      const tempPath = join(tmpdir(), Math.random().toString())
+      const tempPath = join(dirname(dataPath), '.' + Math.random().toString())
       const body = await req.arrayBuffer()
-      await fs.writeFile(tempPath, Buffer.from(body))
       await fs.mkdir(dirname(dataPath), { recursive: true })
+      await fs.writeFile(tempPath, Buffer.from(body))
       await fs.rename(tempPath, dataPath)
 
       if (metadata) {

--- a/packages/blobs/src/server.ts
+++ b/packages/blobs/src/server.ts
@@ -317,7 +317,7 @@ export class BlobsServer {
       // happen if multiple clients try to write to the same key at the same
       // time. To prevent this, we write to a temporary file first and then
       // atomically move it to its final destination.
-      const tempPath = join(dirname(dataPath), `.${Math.random().toString().slice(2)}`)
+      const tempPath = join(dirname(dataPath), `.${Math.random().toString(36).slice(2)}`)
       const body = await req.arrayBuffer()
       await fs.mkdir(dirname(dataPath), { recursive: true })
       await fs.writeFile(tempPath, Buffer.from(body))


### PR DESCRIPTION
relates to https://github.com/withastro/astro/pull/13768

two commits:

1. Use the target directory to store temp files (because `fs.rename` creates a hard link, so if the tmpdir is not on the same volume as the code this will fail -- happens in windows builds)
2. Be more defensive about how we create and destroy the dev server in the vite plugin -- `closeBundle` can run multiple times, and as closely related to dev server lifecycle as the httpServer "close" event