### PR TITLE
feat: support header matching in edge functions

### DIFF
--- a/packages/edge-functions/dev/node/main.ts
+++ b/packages/edge-functions/dev/node/main.ts
@@ -141,10 +141,10 @@ export class EdgeFunctionsHandler {
             return !requestHeaderValue
           }
 
-          if (headerMatch?.matcher === 'regex') {
+          if (requestHeaderValue && headerMatch?.matcher === 'regex') {
             const pattern = new RegExp(headerMatch.pattern)
 
-            return requestHeaderValue && pattern.test(requestHeaderValue)
+            return pattern.test(requestHeaderValue)
           }
 
           return false

--- a/packages/edge-functions/dev/node/main.ts
+++ b/packages/edge-functions/dev/node/main.ts
@@ -129,6 +129,32 @@ export class EdgeFunctionsHandler {
         return
       }
 
+      if (route.headers) {
+        const headerMatches = Object.entries(route.headers).every(([headerName, headerMatch]) => {
+          const requestHeaderValue = req.headers.get(headerName)?.split(', ').join(',')
+
+          if (headerMatch?.matcher === 'exists') {
+            return Boolean(requestHeaderValue)
+          }
+
+          if (headerMatch?.matcher === 'missing') {
+            return !requestHeaderValue
+          }
+
+          if (headerMatch?.matcher === 'regex') {
+            const pattern = new RegExp(headerMatch.pattern)
+
+            return requestHeaderValue && pattern.test(requestHeaderValue)
+          }
+
+          return false
+        })
+
+        if (!headerMatches) {
+          return
+        }
+      }
+
       const isExcludedForFunction = manifest.function_config[route.function]?.excluded_patterns?.some((pattern) =>
         new RegExp(pattern).test(url.pathname),
       )

--- a/packages/edge-functions/dev/node/main.ts
+++ b/packages/edge-functions/dev/node/main.ts
@@ -131,20 +131,20 @@ export class EdgeFunctionsHandler {
 
       if (route.headers) {
         const headerMatches = Object.entries(route.headers).every(([headerName, headerMatch]) => {
-          const requestHeaderValue = req.headers.get(headerName)?.split(', ').join(',')
+          const requestHeaderValue = req.headers.get(headerName)
 
           if (headerMatch?.matcher === 'exists') {
-            return Boolean(requestHeaderValue)
+            return requestHeaderValue !== null
           }
 
           if (headerMatch?.matcher === 'missing') {
-            return !requestHeaderValue
+            return requestHeaderValue === null
           }
 
           if (requestHeaderValue && headerMatch?.matcher === 'regex') {
             const pattern = new RegExp(headerMatch.pattern)
 
-            return pattern.test(requestHeaderValue)
+            return pattern.test(requestHeaderValue.split(', ').join(','))
           }
 
           return false

--- a/packages/edge-functions/src/lib/config.ts
+++ b/packages/edge-functions/src/lib/config.ts
@@ -6,6 +6,8 @@ type OnError = 'fail' | 'bypass' | Path
 
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 
+export type HeadersConfig = Record<string, boolean | string>
+
 type RateLimitAggregator = 'domain' | 'ip'
 
 type RateLimitAction = 'rate_limit' | 'rewrite'
@@ -29,6 +31,7 @@ export interface Config {
   cache?: Cache
   excludedPath?: Path | Path[]
   excludedPattern?: string | string[]
+  header?: HeadersConfig
   onError?: OnError
   path?: Path | Path[]
   pattern?: string | string[]


### PR DESCRIPTION
Closes https://linear.app/netlify/issue/RUN-1783/add-edge-function-matching-by-header-to-primitives-monorepo.