### PR TITLE
build: remove typechecking of nuxt module playground

### DIFF
--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -34,7 +34,7 @@
     "test": "exit 0",
     "test:ci": "vitest run",
     "test:dev": "vitest",
-    "test:types": "vue-tsc --noEmit && nuxi prepare playground && cd playground && vue-tsc --noEmit",
+    "test:types": "vue-tsc --noEmit",
     "test:watch": "vitest watch"
   },
   "keywords": [


### PR DESCRIPTION
There's some intermittent issue in CI that I can't quite figure out:

```
> vue-tsc --noEmit && nuxi prepare playground && cd playground && vue-tsc --noEmit

[success] [nuxi] Types generated in playground/.nuxt
Error: netlify/edge-functions/geo.ts(1,15): error TS2305: Module '"@netlify/edge-functions"' has no exported member 'Context'.
Error: netlify/edge-functions/world-adder.ts(1,15): error TS2305: Module '"@netlify/edge-functions"' has no exported member 'Context'.
```

(example run: https://github.com/netlify/primitives/actions/runs/16378826884/job/46285296127?pr=365)

I think it's some issue at the intersection of npm workspaces + a non-workspace `package.json` within a workspace + referencing a dependency that happens to be in this workspace + maybe CI npm caching...?

Doesn't seem worth spending more time on to just type-check the nuxt module playground.