### PR TITLE
fix: export `Context` type from `@netlify/types`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19880,7 +19880,7 @@
       "dependencies": {
         "@netlify/blobs": "10.0.6",
         "@netlify/dev-utils": "4.0.0",
-        "@netlify/serverless-functions-api": "2.1.3",
+        "@netlify/types": "2.0.2",
         "@netlify/zip-it-and-ship-it": "^14.1.0",
         "cron-parser": "^4.9.0",
         "decache": "^4.6.2",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@netlify/blobs": "10.0.6",
     "@netlify/dev-utils": "4.0.0",
-    "@netlify/serverless-functions-api": "2.1.3",
+    "@netlify/types": "2.0.2",
     "@netlify/zip-it-and-ship-it": "^14.1.0",
     "cron-parser": "^4.9.0",
     "decache": "^4.6.2",

--- a/packages/functions/src/function/v2.ts
+++ b/packages/functions/src/function/v2.ts
@@ -1,4 +1,4 @@
-export type { Context } from '@netlify/serverless-functions-api'
+export type { Context } from '@netlify/types'
 
 type Path = `/${string}`
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'


### PR DESCRIPTION
Exports `Context` type from `@netlify/types` and removes dependency on `@netlify/serverless-functions-api`.

Closes https://github.com/netlify/primitives/issues/302.