### PR TITLE
chore: fix `@netlify/nuxt` flakes due to HMR port conflict

### DIFF
--- a/packages/nuxt-module/test/basic.test.ts
+++ b/packages/nuxt-module/test/basic.test.ts
@@ -7,6 +7,16 @@ describe('ssr', async () => {
   await setup({
     rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
     dev: true,
+    // Disable WebSocket server and HMR to prevent port conflicts in parallel testing
+    // See: https://github.com/vitejs/vite/pull/16219
+    nuxtConfig: {
+      vite: {
+        server: {
+          ws: false,
+          hmr: false,
+        },
+      },
+    },
   })
 
   it('renders the index page', async () => {

--- a/packages/nuxt-module/test/functions.test.ts
+++ b/packages/nuxt-module/test/functions.test.ts
@@ -7,6 +7,16 @@ describe('with user Netlify Functions and Edge Functions', async () => {
   await setup({
     rootDir: fileURLToPath(new URL('./fixtures/with-functions', import.meta.url)),
     dev: true,
+    // Disable WebSocket server and HMR to prevent port conflicts in parallel testing
+    // See: https://github.com/vitejs/vite/pull/16219
+    nuxtConfig: {
+      vite: {
+        server: {
+          ws: false,
+          hmr: false,
+        },
+      },
+    },
   })
 
   it('renders the index page', async () => {


### PR DESCRIPTION
The nuxt module tests run the module in dev mode (because that's the point of our nuxt module), which results in HMR being enabled. Unlike the main vite port, there's no dynamic port selection for the HMR WebSocket port, so when the test files run in parallel they often conflict by trying to bind to the same port.

I could harcode two different ports with `vite.server.hmr.port`, but there's very little value to exercising the HMR code path with these tests, so I just disabled it.

See very similar [Astro testing issue](https://github.com/withastro/astro/pull/11744) similarly resolved by https://github.com/vitejs/vite/pull/16219.