### PR TITLE
chore: fix outstanding eslint errors

### DIFF
--- a/packages/blobs/src/environment.ts
+++ b/packages/blobs/src/environment.ts
@@ -47,7 +47,7 @@ export const getEnvironment = (): EnvironmentVariables => {
 declare global {
   // Using `var` so that the declaration is hoisted in such a way that we can
   // reference it before it's initialized.
-  // eslint-disable-next-line no-var
+
   var netlifyBlobsContext: unknown
 }
 

--- a/packages/cache/src/fetchwithcache.ts
+++ b/packages/cache/src/fetchwithcache.ts
@@ -134,7 +134,11 @@ export const fetchWithCache: FetchWithCache = async (
   if (onCachePut) {
     await onCachePut(cachePut)
   } else {
-    const requestContext = (globalThis as GlobalScope).Netlify?.context
+    // NOTE: when `requestContext` is assigned via a single expression here, we
+    // hit some `@typescript-eslint/no-unsafe-assignment` bug. TODO(serhalp): try
+    // to reduce this down to a minimal repro and file an issue.
+    const netlifyGlobal: NetlifyGlobal | undefined = (globalThis as GlobalScope).Netlify
+    const requestContext = netlifyGlobal?.context
 
     if (requestContext) {
       requestContext.waitUntil(cachePut)

--- a/packages/edge-functions/src/main.ts
+++ b/packages/edge-functions/src/main.ts
@@ -3,7 +3,7 @@ import type { NetlifyGlobal } from '@netlify/types'
 declare global {
   // Using `var` so that the declaration is hoisted in such a way that we can
   // reference it before it's initialized.
-  // eslint-disable-next-line no-var
+
   var Netlify: NetlifyGlobal
 }
 

--- a/packages/runtime/src/lib/globals.ts
+++ b/packages/runtime/src/lib/globals.ts
@@ -7,7 +7,6 @@ declare global {
   // Using `var` so that the declaration is hoisted in such a way that we can
   // reference it before it's initialized.
 
-  // eslint-disable-next-line no-var
   var Netlify: NetlifyGlobal
 }
 


### PR DESCRIPTION
### Work around strange `@typescript-eslint/no-unsafe-assignment` bug

I did a bunch of research on this and I'm fairly confident it's a bug, but I couldn't come up with a minimal repro to open an issue and felt like I couldn't justify spending more time here.

This is a valuable rule, so I'd rather not suppress on this line or globally.

Splitting into two lines resolves it and that seems totally fine, especially with a comment 🤷🏼.

### Remove unused eslint suppressions

### To do

- [ ] when ready to merge, move lint CI check back to required