### PR TITLE
chore: update CODEOWNERS to match all nested paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @netlify/team-runtime
-/packages/dev/* @netlify/ecosystem-pod-frameworks
-/packages/dev-utils/* @netlify/ecosystem-pod-frameworks
-/packages/nuxt-module/* @netlify/ecosystem-pod-frameworks
-/packages/vite-plugin/* @netlify/ecosystem-pod-frameworks
+/packages/dev/**/* @netlify/ecosystem-pod-frameworks
+/packages/dev-utils/**/* @netlify/ecosystem-pod-frameworks
+/packages/nuxt-module/**/* @netlify/ecosystem-pod-frameworks
+/packages/vite-plugin/**/* @netlify/ecosystem-pod-frameworks


### PR DESCRIPTION
See https://github.com/netlify/primitives/pull/376 making changes to files in `packages/nuxt-module/test/` and review being requested from runtime team where it should be frameworks

Also per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax our current syntax matches this example:
```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/* docs@example.com
```

I'm not sure proposed change is fully correct, just that current one doesn't seem correct