### PR TITLE
fix(deps): remove unused chalk dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20095,7 +20095,7 @@
       "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
-        "ipx": "^3.1.0"
+        "ipx": "^3.0.3"
       },
       "devDependencies": {
         "@netlify/dev-utils": "^4.1.0",
@@ -20414,8 +20414,7 @@
       "license": "MIT",
       "dependencies": {
         "@netlify/dev": "4.5.0",
-        "@netlify/dev-utils": "^4.1.0",
-        "chalk": "^5.4.1"
+        "@netlify/dev-utils": "^4.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.17.57",
@@ -20437,18 +20436,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
-      }
-    },
-    "packages/vite-plugin/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/vite-plugin/node_modules/undici-types": {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -41,8 +41,7 @@
   },
   "dependencies": {
     "@netlify/dev": "4.5.0",
-    "@netlify/dev-utils": "^4.1.0",
-    "chalk": "^5.4.1"
+    "@netlify/dev-utils": "^4.1.0"
   },
   "peerDependencies": {
     "vite": "^5 || ^6 || ^7"


### PR DESCRIPTION
We no longer use this in the vite-plugin package, so it should be safe to remove.