### PR TITLE
fix: include html templates with dev-utils package

### DIFF
--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -22,7 +22,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/templates/*.html"
   ],
   "scripts": {
     "build": "tsup-node",


### PR DESCRIPTION
added line to include html templates that were missing in `@netlify/dev-utils` package