### PR TITLE
ci: allow triggering npm release with workflow_dispatch

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,6 +3,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish from'
+        required: true
+        type: string
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -20,89 +27,94 @@ jobs:
         id: release
         with:
           token: ${{ steps.get-token.outputs.token }}
+        if: github.event_name == 'push'
       - uses: actions/checkout@v5
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created || github.event_name == 'workflow_dispatch' }}
         with:
           token: ${{ steps.get-token.outputs.token }}
+          fetch-depth: 0
+      - name: Checkout tag for manual publish
+        if: github.event_name == 'workflow_dispatch'
+        run: git checkout ${{ github.event.inputs.tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: '*'
           cache: 'npm'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created || github.event_name == 'workflow_dispatch' }}
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: 2.2.4
       - run: npm ci
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created || github.event_name == 'workflow_dispatch' }}
       - name: Build packages
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created || github.event_name == 'workflow_dispatch' }}
         run: npm run build --workspaces=true
 
       # Publishing packages in topological order, as defined in `package.json`.
       - run: npm publish packages/types/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/types--release_created'] }}
+        if: ${{ steps.release.outputs['packages/types--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/dev-utils/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/dev-utils--release_created'] }}
+        if: ${{ steps.release.outputs['packages/dev-utils--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/runtime-utils/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/runtime-utils--release_created'] }}
+        if: ${{ steps.release.outputs['packages/runtime-utils--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/blobs/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/blobs--release_created'] }}
+        if: ${{ steps.release.outputs['packages/blobs--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/cache/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/cache--release_created'] }}
+        if: ${{ steps.release.outputs['packages/cache--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/edge-functions/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/edge-functions--release_created'] }}
+        if: ${{ steps.release.outputs['packages/edge-functions--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/functions/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/functions--release_created'] }}
+        if: ${{ steps.release.outputs['packages/functions--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/headers/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/headers--release_created'] }}
+        if: ${{ steps.release.outputs['packages/headers--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/images/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/images--release_created'] }}
+        if: ${{ steps.release.outputs['packages/images--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/nuxt-module/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/nuxt-module--release_created'] }}
+        if: ${{ steps.release.outputs['packages/nuxt-module--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/redirects/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/redirects--release_created'] }}
+        if: ${{ steps.release.outputs['packages/redirects--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/runtime/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/runtime--release_created'] }}
+        if: ${{ steps.release.outputs['packages/runtime--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/static/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/static--release_created'] }}
+        if: ${{ steps.release.outputs['packages/static--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/dev/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/dev--release_created'] }}
+        if: ${{ steps.release.outputs['packages/dev--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/vite-plugin/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/vite-plugin--release_created'] }}
+        if: ${{ steps.release.outputs['packages/vite-plugin--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish packages/otel/ --provenance --access=public
-        if: ${{ steps.release.outputs['packages/otel--release_created'] }}
+        if: ${{ steps.release.outputs['packages/otel--release_created'] || github.event_name == 'workflow_dispatch' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
not tested, generated with copilot but it looks about right

hopefully it would allow to resolve https://linear.app/netlify/issue/FRB-1972/build-failures-due-to-dependency-issue-of-no-matching-version-found

see https://netlify.slack.com/archives/CTCRT6VB6/p1756261623711189 thread and in particular:

> @netlify/blobs@10.0.9 is not on npm
> \> npm info @netlify/blobs@^10 version
> @netlify/blobs@10.0.0 '10.0.0'
> @netlify/blobs@10.0.1 '10.0.1'
> @netlify/blobs@10.0.2 '10.0.2'
> @netlify/blobs@10.0.3 '10.0.3'
> @netlify/blobs@10.0.4 '10.0.4'
> @netlify/blobs@10.0.5 '10.0.5'
> @netlify/blobs@10.0.6 '10.0.6'
> @netlify/blobs@10.0.7 '10.0.7'
> @netlify/blobs@10.0.8 '10.0.8'
> This https://github.com/netlify/primitives/actions/runs/17064432515/job/48378186948 should have released it to npm, but it failed.
> Now since that there were other releases for other packages in this repo after above. Some of those packages depend on @netlify/blobs and because of release-please flows, blobs dependency in other packages (like @netlify/functions etc) was bumped to 10.0.9 , but it can't be resolved on installation due to it not being on npm in first place.
I tried rerunning that failed release please job, but it runs against main and not concrete commit, so it was no-op in the retry run (didn't attempt to publish anything), so I need to find other way to release those missing things to npm