### PR TITLE
fix(vite-plugin): pass environmentVariables option to NetlifyDev

### DIFF
--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -30,7 +30,16 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
         return
       }
       const logger = createLoggerFromViteLogger(viteDevServer.config.logger)
-      const { blobs, edgeFunctions, environmentVariables, functions, images, middleware = true, redirects, staticFiles } = options
+      const {
+        blobs,
+        edgeFunctions,
+        environmentVariables,
+        functions,
+        images,
+        middleware = true,
+        redirects,
+        staticFiles,
+      } = options
 
       const netlifyDev = new NetlifyDev({
         blobs,


### PR DESCRIPTION
The Vite plugin doesn't pass the `environmentVariables` to the `NetlifyDev` constructor, meaning the feature can't be disabled.

Closes https://github.com/withastro/astro/issues/14255