### PR TITLE
feat: export `cacheHeaders` method

### DIFF
--- a/packages/cache/src/cache-headers/cache-headers.test.ts
+++ b/packages/cache/src/cache-headers/cache-headers.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest'
 
-import { cacheHeaders, ONE_YEAR } from './cache-headers.js'
+import { cacheHeaders } from '../main.js'
+import { ONE_YEAR } from './cache-headers.js'
 
 describe('`cacheHaders`', () => {
   describe('`tags`', () => {

--- a/packages/cache/src/main.ts
+++ b/packages/cache/src/main.ts
@@ -1,5 +1,5 @@
 export { caches } from './polyfill.js'
-export { setCacheHeaders } from './cache-headers/cache-headers.js'
+export { cacheHeaders, setCacheHeaders } from './cache-headers/cache-headers.js'
 export { getCacheStatus } from './cache-status/cache-status.js'
 export { fetchWithCache } from './fetchwithcache.js'
 export * from './constants.js'


### PR DESCRIPTION
Exports the `cacheHeaders` method that returns a set of cache headers based on the settings supplied.

_Example_
```ts
import { cacheHeaders, DAY } from "@netlify/cache"

export default async () => new Response("I shall be cached", {
  headers: {
    ...cacheHeaders({
      ttl: 2 * DAY, // Two days
      tags: ["product", "sale"],
      vary: {
        cookie: ["ab_test_name", "ab_test_bucket"],
        query: ["item_id", "page"]
      }
    })
  }
})

```