### PR TITLE
[do-not-merge] Tmp set proper peer deps for tanstack start with legacy peer deps

### DIFF
--- a/packages/vite-plugin-tanstack-start/package.json
+++ b/packages/vite-plugin-tanstack-start/package.json
@@ -49,8 +49,8 @@
     "@netlify/vite-plugin": "^2.5.10"
   },
   "peerDependencies": {
-    "@tanstack/react-start": "alpha",
-    "@tanstack/solid-start": "alpha",
+    "@tanstack/react-start": ">=1.132.0",
+    "@tanstack/solid-start": ">=1.132.0",
     "vite": ">=7.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vite-plugin-tanstack-start/test/support/netlify-deploy.ts
+++ b/packages/vite-plugin-tanstack-start/test/support/netlify-deploy.ts
@@ -59,7 +59,7 @@ const prepareDeps = async (cwd: string, packagesAbsoluteDir: string): Promise<vo
   }
   await writeFile(`${cwd}/package.json`, JSON.stringify(packageJson, null, 2))
   console.log('📦 Installing dependencies...')
-  await exec('npm install --no-package-lock', { cwd })
+  await exec('npm install --no-package-lock --legacy-peer-deps', { cwd })
   console.log('📦 Installed dependencies')
 }
 


### PR DESCRIPTION
This is https://github.com/netlify/primitives/pull/458 + additional npm install flag that is needed to run test until stable `1.132.0` (or whatever version denitro will land on) is released to npm.

This is primary to make sure everything still works