### PR TITLE
fix: add extra types for ratelimiting

### DIFF
--- a/packages/edge-functions/src/lib/config.ts
+++ b/packages/edge-functions/src/lib/config.ts
@@ -20,6 +20,7 @@ interface RateLimitConfig {
   aggregateBy?: RateLimitAggregator | RateLimitAggregator[]
   to?: string
   windowSize: number
+  windowLimit: number
 }
 
 /**

--- a/packages/functions/src/function/v2.ts
+++ b/packages/functions/src/function/v2.ts
@@ -11,6 +11,7 @@ interface RateLimitConfig {
   aggregateBy?: RateLimitAggregator | RateLimitAggregator[]
   to?: string
   windowSize: number
+  windowLimit: number
 }
 
 interface BaseConfig {


### PR DESCRIPTION
Although our config accepts `windowLimit`, our types fail when the option is trying to be used.