### PR TITLE
tmp: adjust release please config for functions split release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,9 @@
     "packages/ai": {},
     "packages/blobs": {},
     "packages/cache": {},
-    "packages/dev": {},
+    "packages/dev": {
+      "exclude-paths": ["packages/dev"]
+    },
     "packages/dev-utils": {},
     "packages/edge-functions": {},
     "packages/functions/dev": {},
@@ -24,6 +26,8 @@
     "packages/static": {},
     "packages/types": {},
     "packages/vite-plugin": {},
-    "packages/vite-plugin-tanstack-start": {}
+    "packages/vite-plugin-tanstack-start": {
+      "exclude-paths": ["packages/vite-plugin-tanstack-start/test"]
+    }
   }
 }


### PR DESCRIPTION
following produce something like this:

<details><summary>dev: 4.6.1</summary>

## [4.6.1](https://github.com/netlify/primitives/compare/dev-v4.6.0...dev-v4.6.1) (2025-10-14)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @netlify/functions-dev bumped from 0.0.0 to 1.0.0
</details>

<details><summary>functions: 5.0.0</summary>

## [5.0.0](https://github.com/netlify/primitives/compare/functions-v4.3.0...functions-v5.0.0) (2025-10-14)


### ⚠ BREAKING CHANGES

* The `/dev` export, introduced in version 3.1.0, has been removed.

### Features

* extract dev logic into new `@netlify/functions-dev` package ([#475](https://github.com/netlify/primitives/issues/475)) ([0730f5f](https://github.com/netlify/primitives/commit/0730f5f40ace6cd37ffc1f54a7ebb4f405bbca65))
</details>

<details><summary>functions-dev: 1.0.0</summary>

## 1.0.0 (2025-10-14)


### ⚠ BREAKING CHANGES

* The `/dev` export, introduced in version 3.1.0, has been removed.

### Features

* extract dev logic into new `@netlify/functions-dev` package ([#475](https://github.com/netlify/primitives/issues/475)) ([0730f5f](https://github.com/netlify/primitives/commit/0730f5f40ace6cd37ffc1f54a7ebb4f405bbca65))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @netlify/functions bumped from 4.3.0 to 5.0.0
</details>

<details><summary>nuxt: 0.2.1</summary>

## [0.2.1](https://github.com/netlify/primitives/compare/nuxt-v0.2.0...nuxt-v0.2.1) (2025-10-14)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @netlify/dev bumped from ^4.6.0 to ^4.6.1
</details>

<details><summary>vite-plugin: 2.7.1</summary>

## [2.7.1](https://github.com/netlify/primitives/compare/vite-plugin-v2.7.0...vite-plugin-v2.7.1) (2025-10-14)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @netlify/dev bumped from 4.6.0 to 4.6.1
</details>

<details><summary>vite-plugin-tanstack-start: 1.1.1</summary>

## [1.1.1](https://github.com/netlify/primitives/compare/vite-plugin-tanstack-start-v1.1.0...vite-plugin-tanstack-start-v1.1.1) (2025-10-14)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @netlify/vite-plugin bumped from ^2.7.0 to ^2.7.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).