### PR TITLE
fix: reset dupe plugin tracker on dev server close

### DIFF
--- a/packages/vite-plugin/src/main.test.ts
+++ b/packages/vite-plugin/src/main.test.ts
@@ -98,6 +98,25 @@ describe.for([['5.0.0'], ['6.0.0'], ['7.0.0']])('Vite %s', ([viteVersion]) => {
       await server.close()
     })
 
+    test('does not warn about duplicate plugin instances when server restarts', async () => {
+      const mockLogger = createMockViteLogger()
+
+      const firstServer = await startTestServer({
+        customLogger: mockLogger,
+        plugins: [netlify({ middleware: false })],
+      })
+      expect(mockLogger.warn).not.toHaveBeenCalled()
+      await firstServer.server.close()
+
+      const secondServer = await startTestServer({
+        customLogger: mockLogger,
+        plugins: [netlify({ middleware: false })],
+      })
+      expect(mockLogger.warn).not.toHaveBeenCalled()
+
+      await secondServer.server.close()
+    })
+
     test('Populates Netlify runtime environment (globals and env vars)', async () => {
       const fixture = new Fixture()
         .withFile(

--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -91,6 +91,11 @@ export default function netlify(options: NetlifyPluginOptions = {}): any {
       await netlifyDev.start()
 
       viteDevServer.httpServer.once('close', () => {
+        // The whole vite dev instance has stopped, so reset the duplicate plugin tracker.
+        // For example, this happens when a user makes a change to `vite.config.ts` and a new server starts.
+        // We shouldn't print a false positive warning in these cases.
+        delete process.env.__VITE_PLUGIN_NETLIFY_LOADED__
+
         netlifyDev.stop()
       })
 


### PR DESCRIPTION
When a user makes a change to their `vite.config.ts`, Vite shuts down the dev server and starts a new one. Since we track instances of our plugin via an env var, this was printing a false positive warning about duplicate plugins.