### PR TITLE
fix: export enums by reference instead of as types

### DIFF
--- a/packages/otel/src/opentelemetry.ts
+++ b/packages/otel/src/opentelemetry.ts
@@ -2,19 +2,10 @@
  * Re-exports of commonly used OpenTelemetry primitives
  * This ensures version compatibility when building custom exporters and processors
  */
-export { context, propagation, trace } from '@opentelemetry/api'
+export { context, propagation, trace, SpanKind, SpanStatusCode } from '@opentelemetry/api'
 export { W3CTraceContextPropagator } from '@opentelemetry/core'
 export { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node'
 
-export type {
-  Attributes,
-  Context,
-  Span,
-  SpanContext,
-  SpanKind,
-  SpanStatus,
-  SpanStatusCode,
-  TimeInput,
-} from '@opentelemetry/api'
+export type { Attributes, Context, Span, SpanContext, SpanStatus, TimeInput } from '@opentelemetry/api'
 export type { ExportResult, ExportResultCode } from '@opentelemetry/core'
 export type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-node'


### PR DESCRIPTION
`SpanKind` and `SpanStatusCode` are enums and as such need to be accessed directly