### PR TITLE
fix: set span error states when fetch operations fail

### DIFF
--- a/packages/otel/src/instrumentations/fetch.ts
+++ b/packages/otel/src/instrumentations/fetch.ts
@@ -61,6 +61,7 @@ export class FetchInstrumentation implements Instrumentation {
       'http.response.status_code': response.status,
       ...this.prepareHeaders('response', response.headers),
     })
+    span.setStatus({ code: response.status >= 400 ? api.SpanStatusCode.ERROR : api.SpanStatusCode.UNSET })
   }
 
   private prepareHeaders(type: 'request' | 'response', headers: Headers): api.Attributes {


### PR DESCRIPTION
Sets the error state on failed operations

Shows up like the following in Axiom:
<img width="1135" height="163" alt="image" src="https://github.com/user-attachments/assets/83c8904a-31f7-41c4-8182-5d7c268ef510" />