### PR TITLE
fix: instrument content-length in blobs `.get` and `.getWithMetadata` methods

### DIFF
--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -198,6 +198,7 @@ export class Store {
       })
 
       span?.setAttributes({
+        'blobs.response.body.size': res.headers.get('content-length') ?? undefined,
         'blobs.response.status': res.status,
       })
 
@@ -328,6 +329,7 @@ export class Store {
       const responseETag = res?.headers.get('etag') ?? undefined
 
       span?.setAttributes({
+        'blobs.response.body.size': res.headers.get('content-length') ?? undefined,
         'blobs.response.etag': responseETag,
         'blobs.response.status': res.status,
       })


### PR DESCRIPTION
Example with those changes deployed:

<img width="705" height="495" alt="image" src="https://github.com/user-attachments/assets/eae26651-3ac5-43c6-9e7b-0ced0a67e6ac" />

