### PR TITLE
fix: add CJS support to `@netlify/runtime-utils` to fix `ERR_REQUIRE_ESM`

### DIFF
--- a/packages/runtime-utils/package.json
+++ b/packages/runtime-utils/package.json
@@ -6,9 +6,25 @@
   "engines": {
     "node": "^18.14.0 || >=20"
   },
-  "main": "./dist/main.js",
-  "exports": "./dist/main.js",
+  "main": "./dist/main.cjs",
+  "module": "./dist/main.js",
   "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/main.d.cts",
+        "default": "./dist/main.cjs"
+      },
+      "import": {
+        "types": "./dist/main.d.ts",
+        "default": "./dist/main.js"
+      },
+      "default": {
+        "types": "./dist/main.d.ts",
+        "default": "./dist/main.js"
+      }
+    }
+  },
   "files": [
     "dist/**/*"
   ],

--- a/packages/runtime-utils/tsup.config.ts
+++ b/packages/runtime-utils/tsup.config.ts
@@ -7,7 +7,10 @@ export default defineConfig([
     clean: true,
     entry: ['src/main.ts'],
     outDir: 'dist',
-    format: ['esm'],
+    // We build both CJS and ESM because @netlify/blobs is dual-format and depends on this package.
+    // When @netlify/blobs becomes ESM-only, we can remove CJS here and go ESM-only too.
+    // See: https://github.com/netlify/primitives/issues/437
+    format: ['cjs', 'esm'],
     dts: true,
     splitting: false,
     watch: argv.includes('--watch'),


### PR DESCRIPTION
## Problem

Fixes #437

When using `@netlify/blobs` in a CJS serverless function, the deployed function fails at runtime with `ERR_REQUIRE_ESM`:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /var/task/node_modules/@netlify/runtime-utils/dist/main.js 
from /var/task/node_modules/@netlify/blobs/dist/main.cjs not supported.
```

### Root Cause

- `@netlify/blobs` is built in both CJS and ESM formats
- The CJS build contains `require('@netlify/runtime-utils')` statements
- `@netlify/runtime-utils` was configured to export **ESM-only**
- Node.js throws `ERR_REQUIRE_ESM` when trying to `require()` an ESM-only module from a CJS context

## Solution

Make `@netlify/runtime-utils` dual-format (CJS + ESM) so it can be consumed by both module systems.

### Changes

1. **`packages/runtime-utils/tsup.config.ts`**: Updated to build both `cjs` and `esm` formats
2. **`packages/runtime-utils/package.json`**: Added proper conditional exports for both formats

### Future Work

When `@netlify/blobs` becomes ESM-only, we can remove CJS support from `@netlify/runtime-utils` as well.

## Testing

✅ CJS build works:
```bash
node -e "const { base64Encode } = require('./packages/runtime-utils/dist/main.cjs'); console.log(base64Encode('test'))"
# Output: dGVzdA==
```

✅ ESM build still works:
```bash
node --input-type=module -e "import { base64Encode } from './packages/runtime-utils/dist/main.js'; console.log(base64Encode('test'))"
# Output: dGVzdA==
```

✅ `@netlify/blobs` CJS build loads successfully:
```bash
node -e "const blobs = require('./packages/blobs/dist/main.cjs'); console.log(typeof blobs.getStore)"
# Output: function
```