### PR TITLE
ci: skip live e2e tests on fork PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,10 +55,26 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Build
         run: npm run build --workspaces=true
+      # Fork PRs don't have access to secrets, so live E2E tests (e.g. Netlify
+      # deploy tests) must be skipped.
+      - name: Flag fork PR
+        if:
+          ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name !=
+          'netlify/primitives' }}
+        run: echo "SKIP_LIVE_TESTS=true" >> "$GITHUB_ENV"
       - name: Tests
         run: npm run test --workspaces=true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      - name: Warn if live tests were skipped
+        if: ${{ env.SKIP_LIVE_TESTS == 'true' }}
+        run: |
+          echo "::warning::Live E2E tests were skipped because secrets are not available (likely a fork PR)."
+          echo "## ⚠️ Live E2E tests were skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This workflow run does not have access to secrets (likely a fork PR)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Live tests that deploy to Netlify were skipped." >> "$GITHUB_STEP_SUMMARY"
+          echo "Maintainers: before merging, verify that these tests pass or aren't relevant." >> "$GITHUB_STEP_SUMMARY"
   test-node18:
     name: Test Node.js 18 for specific packages
     runs-on: ${{ matrix.os }}

--- a/packages/vite-plugin-tanstack-start/test/e2e/build.test.ts
+++ b/packages/vite-plugin-tanstack-start/test/e2e/build.test.ts
@@ -13,8 +13,11 @@ const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url))
 const isSupportedNode = semver.gte(process.versions.node, '22.12.0')
 // TODO(serhalp) e2e fixture deploy fails on Windows - investigate and re-enable
 const isWindows = process.platform === 'win32'
+// Live tests require secrets (e.g. NETLIFY_AUTH_TOKEN) which are unavailable in fork PRs.
+// CI sets SKIP_LIVE_TESTS=true in that case. See .github/workflows/test.yaml.
+const skipLiveTests = process.env.SKIP_LIVE_TESTS === 'true'
 
-describe.runIf(isSupportedNode && !isWindows)('build output when deployed to Netlify', () => {
+describe.runIf(isSupportedNode && !isWindows && !skipLiveTests)('build output when deployed to Netlify', () => {
   let fixture: Fixture
   let baseUrl: string
   beforeAll(async () => {


### PR DESCRIPTION
Some tests always fail on PRs from forks. This is a poor experience for external contributors as well as for maintainers, and it does not foster OSS contributions.

Skip tests that require access to secrets and use GitHub "annotations" to remind maintainers that this has happened.