### PR TITLE
feat: export initializeTrackingTable from @netlify/dev

### DIFF
--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -24,7 +24,7 @@ import { RedirectsHandler } from '@netlify/redirects'
 import { StaticHandler } from '@netlify/static'
 import { NetlifyDB } from '@netlify/database-dev'
 
-export { applyMigrations, resetDatabase } from '@netlify/database-dev'
+export { applyMigrations, initializeTrackingTable, resetDatabase } from '@netlify/database-dev'
 export type { SQLExecutor } from '@netlify/database-dev'
 
 import { InjectedEnvironmentVariable, injectEnvVariables } from './lib/env.js'


### PR DESCRIPTION
This is so it can be reused in CLI.

We already re-export some `@netlify/database-dev` utilities, so following that pattern