### PR TITLE
fix: set NETLIFY_DB_DRIVER to server in dev

### DIFF
--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -529,6 +529,7 @@ export class NetlifyDev {
         const connectionString = await db.start()
 
         runtime.env.set('NETLIFY_DB_URL', connectionString)
+        runtime.env.set('NETLIFY_DB_DRIVER', 'server')
 
         state.set('dbConnectionString', connectionString)
 


### PR DESCRIPTION
This is proper place to address https://github.com/netlify/cli/pull/8219 

Once this is released, CLI change should be reverted and `@netlify/dev` version bumped.