### PR TITLE
fix: workaround deno@2.9.0 compatibility issue

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.5.6
+          deno-version: 2.9.0
 
       - name: Install dependencies
         run: npm ci --no-audit

--- a/.github/workflows/publint.yaml
+++ b/.github/workflows/publint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.5.6
+          deno-version: 2.9.0
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.5.6
+          deno-version: 2.9.0
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created || github.event_name == 'workflow_dispatch' }}
       - name: Build packages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.5.6
+          deno-version: 2.9.0
       - name: Setup Deno dependencies
         run: deno cache https://deno.land/x/eszip@v0.55.2/eszip.ts
       - name: Install dependencies
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.5.6
+          deno-version: 2.9.0
       - name: Setup Deno dependencies
         run: deno cache https://deno.land/x/eszip@v0.55.2/eszip.ts
       - name: Install dependencies

--- a/packages/edge-functions/dev/src/deno/workers/runner.mjs
+++ b/packages/edge-functions/dev/src/deno/workers/runner.mjs
@@ -9,7 +9,7 @@ import { handleRequest } from '../bootstrap.mjs'
  * @typedef {import('./types.ts').RunResponseEndMessage} RunResponseEndMessage
  */
 
-// Deno@2.9.0 lazy loads globalThis.process on first access. In worker thread it will rely on process.cwd() that we
+// Deno@2.9.0 lazy loads globalThis.process on first access. In worker thread it will rely on Deno.cwd() that we
 // don't allow in Edge Functions. Tricking deno into thinking it does run as main process allow
 // us to workaround this case.
 // See https://github.com/denoland/deno/blob/49c38256b8affe8aca3f9893576e44de239f486c/ext/node/polyfills/process.ts#L1801

--- a/packages/edge-functions/dev/src/deno/workers/runner.mjs
+++ b/packages/edge-functions/dev/src/deno/workers/runner.mjs
@@ -9,6 +9,12 @@ import { handleRequest } from '../bootstrap.mjs'
  * @typedef {import('./types.ts').RunResponseEndMessage} RunResponseEndMessage
  */
 
+// Deno@2.9.0 lazy loads globalThis.process on first access. In worker thread it will rely on process.cwd() that we
+// don't allow in Edge Functions. Tricking deno into thinking it does run as main process allow
+// us to workaround this case.
+// See https://github.com/denoland/deno/blob/49c38256b8affe8aca3f9893576e44de239f486c/ext/node/polyfills/process.ts#L1801
+Deno.mainModule = new URL(import.meta.url).href
+
 const consoleLog = globalThis.console.log
 /** @type {Map<string, string>} */
 const fetchRewrites = new Map()


### PR DESCRIPTION
This is alternative to https://github.com/netlify/build/pull/7113

It's much more targetted, because this incompatibility with `deno@2.9.0` exist only in `@netlify/edge-functions-dev` due to running in Worker (which we don't do anywhere else)

https://github.com/netlify/primitives/actions/runs/28254407368/job/83713721091#step:13:513 is example of problem with using `globalThis.process` on `deno@2.9.0` in`@netlify/edge-functions-dev`