### PR TITLE
chore: add context7.json to claim ownership

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/netlify/primitives",
+  "public_key": "pk_o1kJHj61VuNZdp8u5vsq0"
+}


### PR DESCRIPTION
Adds a `context7.json` at the repo root to claim ownership of this repo's [Context7](https://context7.com/netlify/primitives/admin) entry.

Linear: [AX-44](https://linear.app/netlify/issue/AX-44/take-ownership-of-context7-resources)