### PR TITLE
fix(ai): add missing MIT license to `@netlify/ai` package

### DIFF
--- a/packages/ai/LICENSE
+++ b/packages/ai/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2026 Netlify <team@netlify.com>
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -65,6 +65,7 @@
     "typescript": "5.9.3",
     "vitest": "^3.0.0"
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/netlify/primitives.git",


### PR DESCRIPTION
Closes #126