### PR TITLE
fix(blobs): better error message when using site stores during prebuild

### DIFF
--- a/packages/blobs/src/client.ts
+++ b/packages/blobs/src/client.ts
@@ -161,7 +161,7 @@ export class Client {
     })
 
     if (res.status !== 200) {
-      throw new BlobsInternalError(res)
+      throw new BlobsInternalError(res, { method, storeName })
     }
 
     const { url: signedURL } = await res.json()

--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -1123,7 +1123,7 @@ describe('set', () => {
       })
 
       await expect(blobs.set(key, 'value')).rejects.toThrowError(
-        `Netlify Blobs has generated an internal error (401 status code)`,
+        `Netlify Blobs could not write to store 'production' (401 status code). Builds and build plugins can only write to deploy-specific stores: use 'getDeployStore' instead of 'getStore', or pass a 'token' with write access to the store. If this code is not running in a build, check that the token and site ID are valid. See https://docs.netlify.com/build/data-and-storage/netlify-blobs/#deploy-specific-stores`,
       )
       expect(mockStore.fulfilled).toBeTruthy()
     })
@@ -1245,7 +1245,7 @@ describe('set', () => {
       })
 
       await expect(blobs.set(key, value)).rejects.toThrowError(
-        `Netlify Blobs has generated an internal error (401 status code)`,
+        /Netlify Blobs could not write to store 'production' \(401 status code\)/,
       )
 
       expect(mockStore.fulfilled).toBeTruthy()
@@ -1679,7 +1679,7 @@ describe('delete', () => {
       })
 
       await expect(blobs.delete(key)).rejects.toThrowError(
-        `Netlify Blobs has generated an internal error (401 status code)`,
+        /Netlify Blobs could not write to store 'production' \(401 status code\)/,
       )
       expect(mockStore.fulfilled).toBeTruthy()
     })
@@ -1745,7 +1745,7 @@ describe('delete', () => {
       })
 
       await expect(blobs.delete(key)).rejects.toThrowError(
-        `Netlify Blobs has generated an internal error (401 status code)`,
+        /Netlify Blobs could not write to store 'production' \(401 status code\)/,
       )
 
       expect(mockStore.fulfilled).toBeTruthy()
@@ -1792,7 +1792,7 @@ describe('deleteAll', () => {
       })
 
       await expect(blobs.deleteAll()).rejects.toThrowError(
-        `Netlify Blobs has generated an internal error (401 status code)`,
+        /Netlify Blobs could not write to store 'production' \(401 status code\)/,
       )
       expect(mockStore.fulfilled).toBeTruthy()
     })
@@ -1859,7 +1859,7 @@ describe('deleteAll', () => {
       })
 
       await expect(blobs.deleteAll()).rejects.toThrowError(
-        `Netlify Blobs has generated an internal error (401 status code)`,
+        /Netlify Blobs could not write to store 'production' \(401 status code\)/,
       )
 
       expect(mockStore.fulfilled).toBeTruthy()

--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -5,11 +5,11 @@ import { Client, type Conditions } from './client.ts'
 import type { ConsistencyMode } from './consistency.ts'
 import { getMetadataFromResponse, Metadata } from './metadata.ts'
 import { BlobInput, HTTPMethod } from './types.ts'
-import { BlobsInternalError, collectIterator, withSpan } from './util.ts'
+import { BlobsInternalError, collectIterator, DEPLOY_STORE_PREFIX, SITE_STORE_PREFIX, withSpan } from './util.ts'
 
-export const DEPLOY_STORE_PREFIX = 'deploy:'
+export { DEPLOY_STORE_PREFIX, SITE_STORE_PREFIX } from './util.ts'
+
 export const LEGACY_STORE_INTERNAL_PREFIX = 'netlify-internal/legacy-namespace/'
-export const SITE_STORE_PREFIX = 'site:'
 
 const STATUS_OK = 200
 const STATUS_PRE_CONDITION_FAILED = 412
@@ -155,7 +155,7 @@ export class Store {
     const res = await this.client.makeRequest({ key, method: HTTPMethod.DELETE, storeName: this.name })
 
     if (![200, 204, 404].includes(res.status)) {
-      throw new BlobsInternalError(res)
+      throw new BlobsInternalError(res, { method: HTTPMethod.DELETE, storeName: this.name })
     }
   }
 
@@ -167,7 +167,7 @@ export class Store {
       const res = await this.client.makeRequest({ method: HTTPMethod.DELETE, storeName: this.name })
 
       if (res.status !== 200) {
-        throw new BlobsInternalError(res)
+        throw new BlobsInternalError(res, { method: HTTPMethod.DELETE, storeName: this.name })
       }
 
       const data = (await res.json()) as DeleteStoreResponse
@@ -470,7 +470,7 @@ export class Store {
         }
       }
 
-      throw new BlobsInternalError(res)
+      throw new BlobsInternalError(res, { method: HTTPMethod.PUT, storeName: this.name })
     })
   }
 
@@ -518,7 +518,7 @@ export class Store {
         }
       }
 
-      throw new BlobsInternalError(res)
+      throw new BlobsInternalError(res, { method: HTTPMethod.PUT, storeName: this.name })
     })
   }
 

--- a/packages/blobs/src/util.test.ts
+++ b/packages/blobs/src/util.test.ts
@@ -1,6 +1,57 @@
 import { it, expect, describe } from 'vitest'
 
-import { decodeWin32SafeName, encodeWin32SafeName } from './util.ts'
+import { BlobsInternalError, decodeWin32SafeName, encodeWin32SafeName } from './util.ts'
+
+describe('BlobsInternalError', () => {
+  const unauthorizedWrites = [
+    { method: 'put', storeName: 'site:content', displayName: 'content', status: 401 },
+    { method: 'delete', storeName: 'site:content', displayName: 'content', status: 401 },
+    { method: 'put', storeName: 'site:content', displayName: 'content', status: 403 },
+    { method: 'put', storeName: 'legacy-store', displayName: 'legacy-store', status: 401 },
+  ]
+
+  it.each(unauthorizedWrites)(
+    'explains the deploy-store restriction for a $status on $method to $storeName',
+    ({ method, storeName, displayName, status }) => {
+      const error = new BlobsInternalError(new Response(null, { status }), { method, storeName })
+
+      expect(error.message).toContain(`Netlify Blobs could not write to store '${displayName}'`)
+      expect(error.message).toContain(`${String(status)} status code`)
+      expect(error.message).toContain(`getDeployStore`)
+      expect(error.message).not.toContain('internal error')
+    },
+  )
+
+  const internalErrors = [
+    { method: 'put', storeName: 'deploy:6a71bdfde1a6dc000951f3a3', status: 401 },
+    { method: 'get', storeName: 'site:content', status: 401 },
+    { method: 'put', storeName: 'site:content', status: 500 },
+    { method: 'put', storeName: undefined, status: 401 },
+    { method: undefined, storeName: undefined, status: 401 },
+  ]
+
+  it.each(internalErrors)(
+    'keeps the generic message for a $status on $method to $storeName',
+    ({ method, storeName, status }) => {
+      const error = new BlobsInternalError(new Response(null, { status }), { method, storeName })
+
+      expect(error.message).toBe(`Netlify Blobs has generated an internal error (${String(status)} status code)`)
+    },
+  )
+
+  it('keeps the generic message when no context is provided', () => {
+    const error = new BlobsInternalError(new Response(null, { status: 401 }))
+
+    expect(error.message).toBe('Netlify Blobs has generated an internal error (401 status code)')
+  })
+
+  it('includes the request ID in the write-denied message', () => {
+    const response = new Response(null, { headers: { 'x-nf-request-id': 'req_123' }, status: 401 })
+    const error = new BlobsInternalError(response, { method: 'put', storeName: 'site:content' })
+
+    expect(error.message).toContain('401 status code, ID: req_123')
+  })
+})
 
 describe('win32 safe names', () => {
   it('encodes unsafe path parts', () => {

--- a/packages/blobs/src/util.ts
+++ b/packages/blobs/src/util.ts
@@ -4,15 +4,41 @@ import type { Span } from '@netlify/otel/opentelemetry'
 
 import { NF_ERROR, NF_REQUEST_ID } from './headers.ts'
 
+export const DEPLOY_STORE_PREFIX = 'deploy:'
+export const SITE_STORE_PREFIX = 'site:'
+
+interface BlobsErrorContext {
+  method?: string
+  storeName?: string
+}
+
+const isDeniedWrite = (res: Response, { method, storeName }: BlobsErrorContext) =>
+  (res.status === 401 || res.status === 403) &&
+  (method === 'put' || method === 'delete') &&
+  storeName !== undefined &&
+  !storeName.startsWith(DEPLOY_STORE_PREFIX)
+
+const blobsErrorMessage = (res: Response, context: BlobsErrorContext) => {
+  let details = res.headers.get(NF_ERROR) || `${res.status} status code`
+
+  if (res.headers.has(NF_REQUEST_ID)) {
+    details += `, ID: ${res.headers.get(NF_REQUEST_ID)}`
+  }
+
+  if (isDeniedWrite(res, context)) {
+    const storeName = context.storeName?.startsWith(SITE_STORE_PREFIX)
+      ? context.storeName.slice(SITE_STORE_PREFIX.length)
+      : context.storeName
+
+    return `Netlify Blobs could not write to store '${storeName}' (${details}). Builds and build plugins can only write to deploy-specific stores: use 'getDeployStore' instead of 'getStore', or pass a 'token' with write access to the store. If this code is not running in a build, check that the token and site ID are valid. See https://docs.netlify.com/build/data-and-storage/netlify-blobs/#deploy-specific-stores`
+  }
+
+  return `Netlify Blobs has generated an internal error (${details})`
+}
+
 export class BlobsInternalError extends Error {
-  constructor(res: Response) {
-    let details = res.headers.get(NF_ERROR) || `${res.status} status code`
-
-    if (res.headers.has(NF_REQUEST_ID)) {
-      details += `, ID: ${res.headers.get(NF_REQUEST_ID)}`
-    }
-
-    super(`Netlify Blobs has generated an internal error (${details})`)
+  constructor(res: Response, context: BlobsErrorContext = {}) {
+    super(blobsErrorMessage(res, context))
 
     this.name = 'BlobsInternalError'
   }


### PR DESCRIPTION
A 401 on a write from a build previously surfaced as 'Netlify Blobs has generated an internal error (401 status code)', which reads like a platform failure. Builds are intentionally restricted to writing to deploy-specific stores, so unauthorized writes to site stores now point at getDeployStore and the token workaround instead.