### PR TITLE
ci: configure pkg.pr.new pre-release workflow

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,37 @@
+name: prerelease
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          check-latest: true
+      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
+      - name: Setup npm version
+        run: npm install -g npm@10
+      - name: Setup Deno
+        uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1.5.2
+        with:
+          deno-version: 2.9.0
+      - name: Install dependencies
+        run: npm ci
+      - name: Build workspaces
+        run: npm run build --workspaces=true
+      - name: Publish prereleases
+        run: |
+          npm query .workspace | jq -er '.[].location' > "$RUNNER_TEMP/pkg-pr-new-workspaces"
+          mapfile -t workspaces < "$RUNNER_TEMP/pkg-pr-new-workspaces"
+          npm exec -- pkg-pr-new publish "${workspaces[@]}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "execa": "^8.0.1",
         "husky": "^9.0.0",
         "jsdom": "^26",
+        "pkg-pr-new": "^0.0.86",
         "prettier": "^3.0.0",
         "typescript-eslint": "^8.33.0"
       }
@@ -10133,6 +10134,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.86",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.86.tgz",
+      "integrity": "sha512-BwPsw/e1Be7F0SfpxhNc2VSxX7uHgCy46Ck+2Z/vqCwXoePhUBrX/VbcawpAlZgMvQe2iwGbZIQ6HSj9bmCk8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -14589,6 +14600,7 @@
     "packages/ai": {
       "name": "@netlify/ai",
       "version": "0.4.4",
+      "license": "MIT",
       "dependencies": {
         "@netlify/api": "^15.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-n": "17.21.3",
     "execa": "^8.0.1",
     "husky": "^9.0.0",
+    "pkg-pr-new": "^0.0.86",
     "prettier": "^3.0.0",
     "typescript-eslint": "^8.33.0"
   }


### PR DESCRIPTION
We recently switched to Trusted Publishing and revoked access to publish manually.

This introduces a convenient automated pre-release workflow on every PR.