### PR TITLE
fix(blobs): throw when a conditional write fails

### DIFF
--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -11,6 +11,7 @@ import { base64Encode, streamToString } from '../test/util.js'
 import { MissingBlobsEnvironmentError } from './environment.js'
 import { NF_ERROR, NF_REQUEST_ID } from './headers.js'
 import { getDeployStore, getStore, setEnvironmentContext } from './main.js'
+import { BlobsInternalError } from './util.js'
 
 beforeAll(async () => {
   if (semver.lt(nodeVersion, '18.0.0')) {
@@ -355,6 +356,34 @@ describe('get', () => {
         expect(result.etag).toBe('"123"')
         expect(mockStore.fulfilled).toBeTruthy()
       })
+
+      test('Throws when the store returns an unexpected status code', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${apiToken}` },
+            response: new Response(JSON.stringify({ url: signedURL })),
+            url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+          })
+          .put({
+            headers: { 'if-match': etag },
+            response: new Response(null, { status: 400 }),
+            url: signedURL,
+          })
+          .inject()
+
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        const result = blobs.set(key, value, { onlyIfMatch: etag })
+
+        await expect(result).rejects.toThrowError(BlobsInternalError)
+        await expect(result).rejects.toThrowError('Netlify Blobs has generated an internal error (400 status code)')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
     })
   })
 
@@ -552,6 +581,62 @@ describe('get', () => {
 
         expect(result.modified).toBe(true)
         expect(result.etag).toBe('"123"')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Throws when the store returns an unexpected status code', async () => {
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-none-match': '*' },
+            response: new Response(null, { status: 400 }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+          .inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = blobs.set(key, value, { onlyIfNew: true })
+
+        await expect(result).rejects.toThrowError(BlobsInternalError)
+        await expect(result).rejects.toThrowError('Netlify Blobs has generated an internal error (400 status code)')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Throws when the store keeps returning a server error until retries are exhausted', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+
+        // Failed requests are retried `MAX_RETRY` (5, in `src/retry.ts`) times
+        // before the last failing response is returned, so the initial request
+        // and all 5 retries have to be mocked.
+        const attempts = 6
+
+        for (let index = 0; index < attempts; index++) {
+          mockStore.put({
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-match': etag },
+            response: new Response(null, { status: 503 }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+        }
+
+        mockStore.inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = blobs.set(key, value, { onlyIfMatch: etag })
+
+        await expect(result).rejects.toThrowError(BlobsInternalError)
+        await expect(result).rejects.toThrowError('Netlify Blobs has generated an internal error (503 status code)')
         expect(mockStore.fulfilled).toBeTruthy()
       })
 
@@ -1437,6 +1522,35 @@ describe('setJSON', () => {
         expect(result.etag).toBe('"123"')
         expect(mockStore.fulfilled).toBeTruthy()
       })
+
+      test('Throws when the store returns an unexpected status code', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            headers: { authorization: `Bearer ${apiToken}` },
+            response: new Response(JSON.stringify({ url: signedURL })),
+            url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+          })
+          .put({
+            body: JSON.stringify({ value }),
+            headers: { 'if-match': etag },
+            response: new Response(null, { status: 400 }),
+            url: signedURL,
+          })
+          .inject()
+
+        const blobs = getStore({
+          name: 'production',
+          token: apiToken,
+          siteID,
+        })
+
+        const result = blobs.setJSON(key, { value }, { onlyIfMatch: etag })
+
+        await expect(result).rejects.toThrowError(BlobsInternalError)
+        await expect(result).rejects.toThrowError('Netlify Blobs has generated an internal error (400 status code)')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
     })
   })
 
@@ -1591,6 +1705,65 @@ describe('setJSON', () => {
 
         expect(result.modified).toBe(true)
         expect(result.etag).toBe('"123"')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Throws when the store returns an unexpected status code', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+          .put({
+            body: JSON.stringify({ value }),
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-match': etag },
+            response: new Response(null, { status: 400 }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+          .inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = blobs.setJSON(key, { value }, { onlyIfMatch: etag })
+
+        await expect(result).rejects.toThrowError(BlobsInternalError)
+        await expect(result).rejects.toThrowError('Netlify Blobs has generated an internal error (400 status code)')
+        expect(mockStore.fulfilled).toBeTruthy()
+      })
+
+      test('Throws when the store keeps returning a server error until retries are exhausted', async () => {
+        const etag = 'etag-123'
+        const mockStore = new MockFetch()
+
+        // Failed requests are retried `MAX_RETRY` (5, in `src/retry.ts`) times
+        // before the last failing response is returned, so the initial request
+        // and all 5 retries have to be mocked.
+        const attempts = 6
+
+        for (let index = 0; index < attempts; index++) {
+          mockStore.put({
+            body: JSON.stringify({ value }),
+            headers: { authorization: `Bearer ${edgeToken}`, 'if-match': etag },
+            response: new Response(null, { status: 503 }),
+            url: `${edgeURL}/${siteID}/site:production/${key}`,
+          })
+        }
+
+        mockStore.inject()
+
+        const blobs = getStore({
+          edgeURL,
+          name: 'production',
+          token: edgeToken,
+          siteID,
+        })
+
+        const result = blobs.setJSON(key, { value }, { onlyIfMatch: etag })
+
+        await expect(result).rejects.toThrowError(BlobsInternalError)
+        await expect(result).rejects.toThrowError('Netlify Blobs has generated an internal error (503 status code)')
         expect(mockStore.fulfilled).toBeTruthy()
       })
     })

--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -460,7 +460,15 @@ export class Store {
       })
 
       if (conditions) {
-        return res.status === STATUS_PRE_CONDITION_FAILED ? { modified: false } : { etag, modified: true }
+        if (res.status === STATUS_PRE_CONDITION_FAILED) {
+          return { modified: false }
+        }
+
+        // A conditional write can succeed with any 2xx status, not just 200. Any
+        // other status falls through to the error below.
+        if (res.ok) {
+          return { etag, modified: true }
+        }
       }
 
       if (res.status === STATUS_OK) {
@@ -508,7 +516,15 @@ export class Store {
       })
 
       if (conditions) {
-        return res.status === STATUS_PRE_CONDITION_FAILED ? { modified: false } : { etag, modified: true }
+        if (res.status === STATUS_PRE_CONDITION_FAILED) {
+          return { modified: false }
+        }
+
+        // A conditional write can succeed with any 2xx status, not just 200. Any
+        // other status falls through to the error below.
+        if (res.ok) {
+          return { etag, modified: true }
+        }
       }
 
       if (res.status === STATUS_OK) {


### PR DESCRIPTION
A conditional write reports success for every failure that isn't a 412.

`set` and `setJSON` both decide the result with the same two-armed ternary:

```ts
if (conditions) {
  return res.status === STATUS_PRE_CONDITION_FAILED ? { modified: false } : { etag, modified: true }
}
```

412 means the precondition failed. Everything else counts as a successful write.
And since that returns before the `if (res.status === STATUS_OK)` check below it,
the `throw new BlobsInternalError(...)` that ends both methods can never be
reached on this path. `fetchAndRetry` returns the last failing response instead
of throwing, so a store that is down for all six attempts arrives here as an
ordinary 503 and gets reported as `{ etag: '', modified: true }`.

Drop `onlyIfMatch` / `onlyIfNew` and the same call throws correctly. So only the
conditional form swallows the failure, and that's the form whose return value is
the caller's only signal that anything landed.

Both blocks now check 412 first, treat any 2xx as success, and let everything
else fall through to the `BlobsInternalError` that was already there.

I used `res.ok` rather than `res.status === STATUS_OK` on purpose. Conditional
writes succeed with 201, and four existing tests say so (`onlyIfNew` success, API
and edge, both methods). Narrowing to 200 turns those four red, which trades a
silent lost write for a spurious failure. The unconditional path is untouched, so
the two paths now accept different success sets. That asymmetry is intentional
here, though it might deserve its own look.

Fixes #741

### Tests

Six added, spread across the four existing `Conditional writes` blocks:

- a non-retried failing status (400) for `set` and `setJSON` on both the API and
  edge paths, one of them via `onlyIfNew` so `if-none-match` is covered too
- the reporter's exact scenario, a 503 on every attempt until retries run out,
  for `set` and `setJSON`

Each one asserts `BlobsInternalError` and the message, so the status that reached
the throw is pinned rather than assumed.

`packages/blobs` goes from 140 to 146 passing with nothing regressed. The four 201
tests above guard the `res.ok` choice and stay green.

### Notes

- This changes behavior for anyone doing a fire-and-forget conditional write with
  no `try`/`catch`. They get a rejection now where they used to get a false
  success. That is what the issue asks for and what unconditional writes already
  do, but I titled it `fix`, so relabel it if you would rather ship a `feat!`.
- 412 is still the only status mapped to `{ modified: false }`. On the
  API-credentials path the conditional PUT goes to a signed provider URL, so if
  that provider answers a failed `if-match` with a 404 instead of a 412, this
  turns it into a throw. It isn't a regression, since that case returned a
  phantom success before, but someone who knows the provider's status matrix
  should probably check.
- The corrected block is identical in `set` and `setJSON`. I left it duplicated
  to keep the diff shaped like #731. Happy to pull it into a private helper next
  to `getConditions` if you would rather have that.
