### PR TITLE
fix(database): include a username in the local connection string

### DIFF
--- a/packages/database/dev/src/main.test.ts
+++ b/packages/database/dev/src/main.test.ts
@@ -9,7 +9,22 @@ import { NetlifyDB } from './main.js'
 let server: NetlifyDB | undefined
 let tmpDir: tmp.DirectoryResult | undefined
 
+const clients: Client[] = []
+
+const createClient = (connectionString: string) => {
+  const client = new Client({ connectionString })
+
+  clients.push(client)
+
+  return client
+}
+
 afterEach(async () => {
+  // `end()` resolves immediately for a client that never connected or is
+  // already closed, so every registered client can be closed unconditionally.
+  await Promise.all(clients.map((client) => client.end()))
+  clients.length = 0
+
   if (server) {
     await server.stop()
     server = undefined
@@ -55,16 +70,16 @@ test('Accepts client connections when no username can be read from the environme
   delete process.env.PGUSER
   pgDefaults.user = undefined
 
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   try {
     await client.connect()
 
     const result = await client.query<{ value: number }>('SELECT 1 AS value')
     expect(result.rows[0].value).toBe(1)
-
-    await client.end()
   } finally {
+    await client.end()
+
     pgDefaults.user = hostUser
 
     if (PGUSER !== undefined) {
@@ -77,7 +92,7 @@ test('Accepts PostgreSQL client connections', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   await client.connect()
 
@@ -91,7 +106,7 @@ test('Executes basic SQL queries', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   await client.connect()
 
@@ -135,8 +150,8 @@ test('Supports multiple concurrent client connections', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const client1 = new Client({ connectionString })
-  const client2 = new Client({ connectionString })
+  const client1 = createClient(connectionString)
+  const client2 = createClient(connectionString)
 
   await client1.connect()
   await client2.connect()
@@ -173,7 +188,7 @@ test('Persists data to disk when directory is provided', async () => {
   server = new NetlifyDB({ directory: tmpDir.path })
   const connectionString1 = await server.start()
 
-  const client1 = new Client({ connectionString: connectionString1 })
+  const client1 = createClient(connectionString1)
 
   await client1.connect()
 
@@ -193,7 +208,7 @@ test('Persists data to disk when directory is provided', async () => {
   server = new NetlifyDB({ directory: tmpDir.path })
   const connectionString2 = await server.start()
 
-  const client2 = new Client({ connectionString: connectionString2 })
+  const client2 = createClient(connectionString2)
 
   await client2.connect()
 
@@ -210,7 +225,7 @@ test('Uses in-memory storage when no directory is provided', async () => {
   server = new NetlifyDB()
   const connectionString1 = await server.start()
 
-  const client1 = new Client({ connectionString: connectionString1 })
+  const client1 = createClient(connectionString1)
 
   await client1.connect()
 
@@ -233,7 +248,7 @@ test('Uses in-memory storage when no directory is provided', async () => {
   server = new NetlifyDB()
   const connectionString2 = await server.start()
 
-  const client2 = new Client({ connectionString: connectionString2 })
+  const client2 = createClient(connectionString2)
 
   await client2.connect()
 
@@ -247,8 +262,8 @@ test('Delivers LISTEN/NOTIFY across separate connections', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const listener = new Client({ connectionString })
-  const notifier = new Client({ connectionString })
+  const listener = createClient(connectionString)
+  const notifier = createClient(connectionString)
 
   await listener.connect()
   await notifier.connect()
@@ -281,8 +296,8 @@ test('Supports UNLISTEN to stop receiving notifications', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const listener = new Client({ connectionString })
-  const notifier = new Client({ connectionString })
+  const listener = createClient(connectionString)
+  const notifier = createClient(connectionString)
 
   await listener.connect()
   await notifier.connect()
@@ -311,9 +326,9 @@ test('Delivers notifications to multiple listeners', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const listener1 = new Client({ connectionString })
-  const listener2 = new Client({ connectionString })
-  const notifier = new Client({ connectionString })
+  const listener1 = createClient(connectionString)
+  const listener2 = createClient(connectionString)
+  const notifier = createClient(connectionString)
 
   await listener1.connect()
   await listener2.connect()
@@ -348,9 +363,9 @@ test('Cleans up subscriptions when a connection closes', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const listener = new Client({ connectionString })
-  const notifier = new Client({ connectionString })
-  const observer = new Client({ connectionString })
+  const listener = createClient(connectionString)
+  const notifier = createClient(connectionString)
+  const observer = createClient(connectionString)
 
   await listener.connect()
   await notifier.connect()
@@ -383,8 +398,8 @@ test('Handles quoted channel names', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const listener = new Client({ connectionString })
-  const notifier = new Client({ connectionString })
+  const listener = createClient(connectionString)
+  const notifier = createClient(connectionString)
 
   await listener.connect()
   await notifier.connect()
@@ -409,7 +424,7 @@ test('Resets the database by dropping all tables', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   await client.connect()
 
@@ -435,7 +450,7 @@ test('Allows creating tables again after reset', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   await client.connect()
 
@@ -453,7 +468,7 @@ test('Drops custom schemas on reset', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   await client.connect()
 
@@ -478,7 +493,7 @@ test('Stops the server cleanly', async () => {
   const connectionString = await server.start()
 
   // Verify server is running
-  const client = new Client({ connectionString })
+  const client = createClient(connectionString)
 
   await client.connect()
   await client.end()
@@ -488,7 +503,7 @@ test('Stops the server cleanly', async () => {
   server = undefined
 
   // New connections should fail
-  const client2 = new Client({ connectionString })
+  const client2 = createClient(connectionString)
 
   await expect(client2.connect()).rejects.toThrow()
 })

--- a/packages/database/dev/src/main.test.ts
+++ b/packages/database/dev/src/main.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs'
 
-import { Client } from 'pg'
+import { Client, defaults as pgDefaults } from 'pg'
 import tmp from 'tmp-promise'
 import { test, expect, afterEach } from 'vitest'
 
@@ -25,7 +25,7 @@ test('Starts a server and returns a connection string', async () => {
   server = new NetlifyDB()
   const connectionString = await server.start()
 
-  expect(connectionString).toMatch(/^postgres:\/\/localhost:\d+\/postgres$/)
+  expect(connectionString).toMatch(/^postgres:\/\/postgres@localhost:\d+\/postgres$/)
 })
 
 test('Uses the specified port when provided', async () => {
@@ -33,7 +33,44 @@ test('Uses the specified port when provided', async () => {
   server = new NetlifyDB({ port })
   const connectionString = await server.start()
 
-  expect(connectionString).toBe(`postgres://localhost:${String(port)}/postgres`)
+  expect(connectionString).toBe(`postgres://postgres@localhost:${String(port)}/postgres`)
+})
+
+test('Returns a connection string that carries a username', async () => {
+  server = new NetlifyDB()
+  const connectionString = await server.start()
+
+  expect(new URL(connectionString).username).not.toBe('')
+})
+
+test('Accepts client connections when no username can be read from the environment', async () => {
+  server = new NetlifyDB()
+  const connectionString = await server.start()
+
+  const { PGUSER } = process.env
+  const hostUser = pgDefaults.user
+
+  // Edge Functions isolates expose neither `PGUSER` nor `USER`, so `pg` has no
+  // username to put in the startup message.
+  delete process.env.PGUSER
+  pgDefaults.user = undefined
+
+  const client = new Client({ connectionString })
+
+  try {
+    await client.connect()
+
+    const result = await client.query<{ value: number }>('SELECT 1 AS value')
+    expect(result.rows[0].value).toBe(1)
+
+    await client.end()
+  } finally {
+    pgDefaults.user = hostUser
+
+    if (PGUSER !== undefined) {
+      process.env.PGUSER = PGUSER
+    }
+  }
 })
 
 test('Accepts PostgreSQL client connections', async () => {

--- a/packages/database/dev/src/main.ts
+++ b/packages/database/dev/src/main.ts
@@ -14,6 +14,11 @@ export type { SQLExecutor } from './lib/sql-executor.js'
 
 const DEFAULT_HOST = 'localhost'
 
+// pg-gateway rejects any startup message without a `user`, and `pg` only falls
+// back to `process.env.USER`, which Edge Functions isolates don't expose. The
+// server authenticates with `trust`, so the value is arbitrary.
+const DEFAULT_USER = 'postgres'
+
 type Logger = (...message: unknown[]) => void
 
 export interface NetlifyDBOptions {
@@ -99,7 +104,7 @@ export class NetlifyDB implements SQLExecutor {
         const { address, port } = this.server?.address() as AddressInfo
         const host = address === '::1' || address === '127.0.0.1' ? 'localhost' : address
 
-        resolve(`postgres://${host}:${String(port)}/postgres`)
+        resolve(`postgres://${DEFAULT_USER}@${host}:${String(port)}/postgres`)
       })
     })
   }


### PR DESCRIPTION
Fixes [RUN-3231](https://linear.app/netlify/issue/RUN-3231/local-netlify-database-fails-in-edge-functions-with-user-is-required).

```
getDatabase().sql`SELECT 1` from an Edge Function against the local database fails with `user is required`, under both `netlify dev` and the Vite plugin.
```

## Cause

`NetlifyDB.start()` returned `postgres://<host>:<port>/postgres`, with no username, leaving the client to supply one. `pg` resolves `user` from the connection string, then `PGUSER`, then `defaults.user` — which it captures at module load from `process.env.USER`. An Edge Functions isolate exposes none of those, so `pg` omits `user` from the startup message.

pg-gateway then rejects the connection before it consults the auth method:

```js
if (!i.user) { yield e.create({ severity: "FATAL", code: "08000", message: "user is required" }).flush() }
```

So `trust` auth never gets a chance, and the FATAL surfaces to the caller through the pool.

## Fix

Generate the URL with an explicit `postgres` username, so it stands on its own rather than depending on ambient process state. Auth is `trust`, so the value is arbitrary; `postgres` matches the database name and PGlite's convention.

This removes the need for the loopback-username workaround reporters have been applying before calling `getDatabase()`.