### PR TITLE
fix(deps): replace `extract-zip` with `yauzl`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3190,7 +3190,7 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -3200,7 +3200,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -3288,11 +3288,11 @@
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5595,15 +5595,6 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.22.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
@@ -6463,41 +6454,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6607,15 +6563,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -9551,15 +9498,6 @@
         "ufo": "^1.6.1"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -10299,16 +10237,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -14295,12 +14223,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -14482,22 +14404,15 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
+        "pend": "~1.2.0"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/yazl": {
@@ -15257,18 +15172,19 @@
         "@netlify/zip-it-and-ship-it": "^15.4.0",
         "cron-parser": "^5.0.0",
         "decache": "^4.6.2",
-        "extract-zip": "^2.0.1",
         "is-stream": "^4.0.1",
         "jwt-decode": "^4.0.0",
         "lambda-local": "^2.2.0",
         "read-package-up": "^12.0.0",
         "semver": "^7.6.3",
-        "source-map-support": "^0.5.21"
+        "source-map-support": "^0.5.21",
+        "yauzl": "^3.4.0"
       },
       "devDependencies": {
         "@netlify/test-utils": "*",
         "@types/semver": "^7.5.8",
         "@types/source-map-support": "^0.5.10",
+        "@types/yauzl": "^3.4.0",
         "@types/yazl": "^3.3.1",
         "npm-run-all2": "^5.0.0",
         "tsup": "^8.0.2",

--- a/packages/functions/dev/package.json
+++ b/packages/functions/dev/package.json
@@ -48,18 +48,19 @@
     "@netlify/zip-it-and-ship-it": "^15.4.0",
     "cron-parser": "^5.0.0",
     "decache": "^4.6.2",
-    "extract-zip": "^2.0.1",
     "is-stream": "^4.0.1",
     "jwt-decode": "^4.0.0",
     "lambda-local": "^2.2.0",
     "read-package-up": "^12.0.0",
     "semver": "^7.6.3",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "yauzl": "^3.4.0"
   },
   "devDependencies": {
     "@netlify/test-utils": "*",
     "@types/semver": "^7.5.8",
     "@types/source-map-support": "^0.5.10",
+    "@types/yauzl": "^3.4.0",
     "@types/yazl": "^3.3.1",
     "npm-run-all2": "^5.0.0",
     "tsup": "^8.0.2",

--- a/packages/functions/dev/src/registry.ts
+++ b/packages/functions/dev/src/registry.ts
@@ -7,11 +7,11 @@ import type { EnvironmentContext as BlobsContext } from '@netlify/blobs'
 import { DevEventHandler, FileWatcher, type FileWatchSubscriptionHandle, Reactive } from '@netlify/dev-utils'
 import { SYNCHRONOUS_FUNCTION_TIMEOUT, BACKGROUND_FUNCTION_TIMEOUT } from '@netlify/functions'
 import { ListedFunction, listFunctions, Manifest } from '@netlify/zip-it-and-ship-it'
-import extractZip from 'extract-zip'
 
 import { BuildCache } from './builder.js'
 import { NetlifyFunction } from './function.js'
 import { runtimes } from './runtimes/index.js'
+import { extractZip } from './zip.js'
 
 export const DEFAULT_FUNCTION_URL_EXPRESSION = /^\/.netlify\/(functions|builders)\/([^/]+).*/
 const TYPES_PACKAGE = '@netlify/functions'
@@ -510,7 +510,7 @@ export class FunctionsRegistry {
   async unzipFunction(func: NetlifyFunction) {
     const targetDirectory = resolve(this.projectRoot, this.destPath, '.unzipped', func.name)
 
-    await extractZip(func.mainFile, { dir: targetDirectory })
+    await extractZip(func.mainFile, targetDirectory)
 
     return targetDirectory
   }

--- a/packages/functions/dev/src/zip.ts
+++ b/packages/functions/dev/src/zip.ts
@@ -1,0 +1,79 @@
+import { once } from 'node:events'
+import { constants as fsConstants, createWriteStream } from 'node:fs'
+import { mkdir, realpath, symlink } from 'node:fs/promises'
+import { dirname, join, relative, sep } from 'node:path'
+import { buffer } from 'node:stream/consumers'
+import { pipeline } from 'node:stream/promises'
+
+import { type Entry, openPromise, type ZipFile } from 'yauzl'
+
+const DOS_DIRECTORY_ATTRIBUTE = 0x10
+
+// ZIP stores the Unix mode in the upper 16 bits of external attributes.
+const getEntryMode = (entry: Entry) => (entry.externalFileAttributes >> 16) & 0xffff
+
+const isDirectoryEntry = (entry: Entry, mode: number) => {
+  if ((mode & fsConstants.S_IFMT) === fsConstants.S_IFDIR || entry.fileName.endsWith('/')) {
+    return true
+  }
+
+  // The upper byte identifies the platform that created the entry.
+  const madeBy = entry.versionMadeBy >> 8
+
+  // DOS archives can mark directories only through the external attributes field.
+  return madeBy === 0 && entry.externalFileAttributes === DOS_DIRECTORY_ATTRIBUTE
+}
+
+const extractEntry = async (zipFile: ZipFile, entry: Entry, targetDirectory: string) => {
+  const destination = join(targetDirectory, entry.fileName)
+  const destinationDirectory = dirname(destination)
+
+  await mkdir(destinationDirectory, { recursive: true })
+
+  const canonicalDestinationDirectory = await realpath(destinationDirectory)
+  const relativeDestinationDirectory = relative(targetDirectory, canonicalDestinationDirectory)
+
+  if (relativeDestinationDirectory.split(sep).includes('..')) {
+    throw new Error(
+      `Out of bound path "${canonicalDestinationDirectory}" found while processing file ${entry.fileName}`,
+    )
+  }
+
+  const mode = getEntryMode(entry)
+  const isDirectory = isDirectoryEntry(entry, mode)
+  // Strip file-type bits before passing permissions to the filesystem.
+  const extractedMode = (mode || (isDirectory ? 0o755 : 0o644)) & 0o777
+
+  if (isDirectory) {
+    await mkdir(destination, { mode: extractedMode, recursive: true })
+    return
+  }
+
+  const readStream = await zipFile.openReadStreamPromise(entry)
+
+  if ((mode & fsConstants.S_IFMT) === fsConstants.S_IFLNK) {
+    await symlink((await buffer(readStream)).toString('utf8'), destination)
+    return
+  }
+
+  await pipeline(readStream, createWriteStream(destination, { mode: extractedMode }))
+}
+
+export const extractZip = async (archivePath: string, targetDirectory: string) => {
+  await mkdir(targetDirectory, { recursive: true })
+
+  const canonicalTargetDirectory = await realpath(targetDirectory)
+  const zipFile = await openPromise(archivePath, { autoClose: false })
+  const closePromise = once(zipFile, 'close')
+
+  try {
+    for await (const entry of zipFile.eachEntry()) {
+      if (!entry.fileName.startsWith('__MACOSX/')) {
+        await extractEntry(zipFile, entry, canonicalTargetDirectory)
+      }
+    }
+  } finally {
+    zipFile.close()
+    await closePromise
+  }
+}


### PR DESCRIPTION
[`extract-zip`](https://npmx.dev/package/extract-zip) has been unmaintained for more 6+ years and now has unpatched CVEs that we cannot resolve other than by removing/replacing it. It also happens to add 14 dependencies and ~2.8 MB as a wrapper around `yauzl`.

This PR switches to using the maintained [`yauzl`](https://npmx.dev/package/yauzl) directly, which has zero deps of its own and weighs only ~110 kB, while preserving existing behaviour.

The previous stacked PR (https://github.com/netlify/primitives/pull/761) added exhaustive test coverage to all relevant behaviour, to ensure the switch is safe.

Closes https://github.com/netlify/primitives/issues/752
Closes https://github.com/netlify/cli/issues/8396#issuecomment-5418170210