### PR TITLE
fix: retry using new signed url and improve messaging for failed requests

### DIFF
--- a/packages/blobs/src/client.ts
+++ b/packages/blobs/src/client.ts
@@ -164,7 +164,7 @@ export class Client {
       throw await createBlobsInternalError(res, { method, storeName })
     }
 
-    const { url: signedURL } = await res.json()
+    const { url: signedURL } = (await res.json()) as { url: string }
     const userHeaders = encodedMetadata ? { [METADATA_HEADER_INTERNAL]: encodedMetadata } : undefined
 
     return {

--- a/packages/blobs/src/client.ts
+++ b/packages/blobs/src/client.ts
@@ -4,7 +4,7 @@ import { encodeMetadata, Metadata, METADATA_HEADER_EXTERNAL, METADATA_HEADER_INT
 import { InvalidBlobsRegionError, isValidRegion } from './region.ts'
 import { fetchAndRetry } from './retry.ts'
 import { BlobInput, Fetcher, HTTPMethod } from './types.ts'
-import { BlobsInternalError } from './util.ts'
+import { createBlobsInternalError } from './util.ts'
 
 export const SIGNED_URL_ACCEPT_HEADER = 'application/json;type=signed-url'
 
@@ -161,7 +161,7 @@ export class Client {
     })
 
     if (res.status !== 200) {
-      throw new BlobsInternalError(res, { method, storeName })
+      throw await createBlobsInternalError(res, { method, storeName })
     }
 
     const { url: signedURL } = await res.json()
@@ -219,7 +219,24 @@ export class Client {
       options.duplex = 'half'
     }
 
-    return fetchAndRetry(this.fetch, url, options)
+    // mint a fresh signed URL if the previous one expired
+    const usesSignedUrl =
+      !this.edgeURL &&
+      key !== undefined &&
+      storeName !== undefined &&
+      method !== HTTPMethod.HEAD &&
+      method !== HTTPMethod.DELETE
+
+    let getRetryUrl
+
+    if (usesSignedUrl) {
+      getRetryUrl = async () => {
+        const finalRequest = await this.getFinalRequest({ consistency, key, metadata, method, parameters, storeName })
+        return finalRequest.url
+      }
+    }
+
+    return fetchAndRetry(this.fetch, url, options, undefined, getRetryUrl)
   }
 }
 

--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -1145,9 +1145,6 @@ describe('set', () => {
     })
 
     test('Retries failed operations', async () => {
-      // A signed URL can expire between when it's issued and when a retry actually
-      // happens, so each retry re-requests a fresh signed URL instead of reusing the
-      // original one - see FRB-2338.
       const getSignedUrl = () => ({
         headers: { authorization: `Bearer ${apiToken}` },
         response: new Response(JSON.stringify({ url: signedURL })),

--- a/packages/blobs/src/main.test.ts
+++ b/packages/blobs/src/main.test.ts
@@ -1145,6 +1145,69 @@ describe('set', () => {
     })
 
     test('Retries failed operations', async () => {
+      // A signed URL can expire between when it's issued and when a retry actually
+      // happens, so each retry re-requests a fresh signed URL instead of reusing the
+      // original one - see FRB-2338.
+      const getSignedUrl = () => ({
+        headers: { authorization: `Bearer ${apiToken}` },
+        response: new Response(JSON.stringify({ url: signedURL })),
+        url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+      })
+
+      const mockStore = new MockFetch()
+        .put(getSignedUrl())
+        .put({
+          body: value,
+          headers: {
+            'cache-control': 'max-age=0, stale-while-revalidate=60',
+          },
+          response: new Response(null, { status: 500 }),
+          url: signedURL,
+        })
+        .put(getSignedUrl())
+        .put({
+          body: value,
+          headers: {
+            'cache-control': 'max-age=0, stale-while-revalidate=60',
+          },
+          response: new Error('Some network problem'),
+          url: signedURL,
+        })
+        .put(getSignedUrl())
+        .put({
+          body: value,
+          headers: {
+            'cache-control': 'max-age=0, stale-while-revalidate=60',
+          },
+          response: new Response(null, { headers: { 'X-RateLimit-Reset': '10' }, status: 429 }),
+          url: signedURL,
+        })
+        .put(getSignedUrl())
+        .put({
+          body: value,
+          headers: {
+            'cache-control': 'max-age=0, stale-while-revalidate=60',
+          },
+          response: new Response(null),
+          url: signedURL,
+        })
+        .inject()
+
+      const blobs = getStore({
+        name: 'production',
+        token: apiToken,
+        siteID,
+      })
+
+      await blobs.set(key, value)
+
+      expect(mockStore.fulfilled).toBeTruthy()
+    })
+
+    test('Retries a 403 on the signed URL PUT by requesting a fresh one', async () => {
+      const expiredError = `<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Request has expired</Message></Error>`
+
       const mockStore = new MockFetch()
         .put({
           headers: { authorization: `Bearer ${apiToken}` },
@@ -1156,24 +1219,13 @@ describe('set', () => {
           headers: {
             'cache-control': 'max-age=0, stale-while-revalidate=60',
           },
-          response: new Response(null, { status: 500 }),
+          response: new Response(expiredError, { status: 403 }),
           url: signedURL,
         })
         .put({
-          body: value,
-          headers: {
-            'cache-control': 'max-age=0, stale-while-revalidate=60',
-          },
-          response: new Error('Some network problem'),
-          url: signedURL,
-        })
-        .put({
-          body: value,
-          headers: {
-            'cache-control': 'max-age=0, stale-while-revalidate=60',
-          },
-          response: new Response(null, { headers: { 'X-RateLimit-Reset': '10' }, status: 429 }),
-          url: signedURL,
+          headers: { authorization: `Bearer ${apiToken}` },
+          response: new Response(JSON.stringify({ url: signedURL })),
+          url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
         })
         .put({
           body: value,

--- a/packages/blobs/src/retry.ts
+++ b/packages/blobs/src/retry.ts
@@ -23,10 +23,7 @@ export const fetchAndRetry = async (
     // almost always means the URL expired before we got to it, rather than a
     // genuine permissions error (those are caught earlier, when the signed
     // URL itself is requested from the Netlify API).
-    const isRetryable =
-      res.status === 429 ||
-      res.status >= 500 ||
-      (getRetryUrl !== undefined && res.status === 403)
+    const isRetryable = res.status === 429 || res.status >= 500 || (getRetryUrl !== undefined && res.status === 403)
 
     if (attemptsLeft > 0 && isRetryable) {
       const delay = getDelay(res.headers.get(RATE_LIMIT_HEADER))

--- a/packages/blobs/src/retry.ts
+++ b/packages/blobs/src/retry.ts
@@ -7,21 +7,32 @@ const MIN_RETRY_DELAY = 1000
 const MAX_RETRY = 5
 const RATE_LIMIT_HEADER = 'X-RateLimit-Reset'
 
+export type GetRetryUrl = () => Promise<string>
+
 export const fetchAndRetry = async (
   fetch: Fetcher,
   url: string,
   options: RequestInit,
   attemptsLeft = MAX_RETRY,
+  getRetryUrl?: GetRetryUrl,
 ): ReturnType<typeof globalThis.fetch> => {
   try {
     const res = await fetch(url, options)
 
-    if (attemptsLeft > 0 && (res.status === 429 || res.status >= 500)) {
+    // A 403 is only treated as retryable for signed-URL requests, where it
+    // almost always means the URL expired before we got to it, rather than a
+    // genuine permissions error (those are caught earlier, when the signed
+    // URL itself is requested from the Netlify API).
+    const isRetryable =
+      res.status === 429 ||
+      res.status >= 500 ||
+      (getRetryUrl !== undefined && res.status === 403)
+
+    if (attemptsLeft > 0 && isRetryable) {
       const delay = getDelay(res.headers.get(RATE_LIMIT_HEADER))
-
       await sleep(delay)
-
-      return fetchAndRetry(fetch, url, options, attemptsLeft - 1)
+      const retryUrl = getRetryUrl ? await getRetryUrl() : url
+      return fetchAndRetry(fetch, retryUrl, options, attemptsLeft - 1, getRetryUrl)
     }
 
     return res
@@ -31,10 +42,9 @@ export const fetchAndRetry = async (
     }
 
     const delay = getDelay()
-
     await sleep(delay)
-
-    return fetchAndRetry(fetch, url, options, attemptsLeft - 1)
+    const retryUrl = getRetryUrl ? await getRetryUrl() : url
+    return fetchAndRetry(fetch, retryUrl, options, attemptsLeft - 1, getRetryUrl)
   }
 }
 

--- a/packages/blobs/src/store.ts
+++ b/packages/blobs/src/store.ts
@@ -5,7 +5,14 @@ import { Client, type Conditions } from './client.ts'
 import type { ConsistencyMode } from './consistency.ts'
 import { getMetadataFromResponse, Metadata } from './metadata.ts'
 import { BlobInput, HTTPMethod } from './types.ts'
-import { BlobsInternalError, collectIterator, DEPLOY_STORE_PREFIX, SITE_STORE_PREFIX, withSpan } from './util.ts'
+import {
+  BlobsInternalError,
+  collectIterator,
+  createBlobsInternalError,
+  DEPLOY_STORE_PREFIX,
+  SITE_STORE_PREFIX,
+  withSpan,
+} from './util.ts'
 
 export { DEPLOY_STORE_PREFIX, SITE_STORE_PREFIX } from './util.ts'
 
@@ -470,7 +477,7 @@ export class Store {
         }
       }
 
-      throw new BlobsInternalError(res, { method: HTTPMethod.PUT, storeName: this.name })
+      throw await createBlobsInternalError(res, { method: HTTPMethod.PUT, storeName: this.name })
     })
   }
 

--- a/packages/blobs/src/util.ts
+++ b/packages/blobs/src/util.ts
@@ -18,7 +18,7 @@ const isDeniedWrite = (res: Response, { method, storeName }: BlobsErrorContext) 
   storeName !== undefined &&
   !storeName.startsWith(DEPLOY_STORE_PREFIX)
 
-const blobsErrorMessage = (res: Response, context: BlobsErrorContext) => {
+const blobsErrorMessage = (res: Response, context: BlobsErrorContext, responseBody?: string) => {
   let details = res.headers.get(NF_ERROR) || `${res.status} status code`
 
   if (res.headers.has(NF_REQUEST_ID)) {
@@ -33,15 +33,44 @@ const blobsErrorMessage = (res: Response, context: BlobsErrorContext) => {
     return `Netlify Blobs could not write to store '${storeName}' (${details}). Builds and build plugins can only write to deploy-specific stores: use 'getDeployStore' instead of 'getStore', or pass a 'token' with write access to the store. If this code is not running in a build, check that the token and site ID are valid. See https://docs.netlify.com/build/data-and-storage/netlify-blobs/#deploy-specific-stores`
   }
 
-  return `Netlify Blobs has generated an internal error (${details})`
+  let message = `Netlify Blobs has generated an internal error (${details})`
+
+  // fall back to raw body: see FRB-2338
+  if (!res.headers.get(NF_ERROR) && responseBody) {
+    message += `: ${responseBody}`
+  }
+
+  return message
 }
 
 export class BlobsInternalError extends Error {
-  constructor(res: Response, context: BlobsErrorContext = {}) {
-    super(blobsErrorMessage(res, context))
+  readonly responseBody?: string
+  readonly status: number
+
+  constructor(res: Response, context: BlobsErrorContext = {}, responseBody?: string) {
+    super(blobsErrorMessage(res, context, responseBody))
 
     this.name = 'BlobsInternalError'
+    this.status = res.status
+    this.responseBody = responseBody
   }
+}
+
+/**
+ * Builds a BlobsInternalError, reading the response body first so that it can be
+ * surfaced when there's no more specific detail available. Use this instead of the
+ * constructor directly wherever the response body might be diagnostic.
+ */
+export const createBlobsInternalError = async (
+  res: Response,
+  context: BlobsErrorContext = {},
+): Promise<BlobsInternalError> => {
+  const responseBody = await res
+    .clone()
+    .text()
+    .catch(() => undefined)
+
+  return new BlobsInternalError(res, context, responseBody)
 }
 
 export const collectIterator = async <T>(iterator: AsyncIterable<T>): Promise<T[]> => {

--- a/packages/database/prod/src/main.ts
+++ b/packages/database/prod/src/main.ts
@@ -47,11 +47,10 @@ export function getConnectionString(): string {
 function ensureNeonWebSocket(): void {
   // We can remove this, and the dependency on `ws`, once we stop supporting
   // Node.js 22.
-   
+
   if (!neonConfig.webSocketConstructor && typeof WebSocket === 'undefined') {
     neonConfig.webSocketConstructor = ws
   }
-   
 }
 
 // Returns an HTTP client that lazily loads the connection string from the

--- a/packages/database/prod/src/main.ts
+++ b/packages/database/prod/src/main.ts
@@ -47,11 +47,11 @@ export function getConnectionString(): string {
 function ensureNeonWebSocket(): void {
   // We can remove this, and the dependency on `ws`, once we stop supporting
   // Node.js 22.
-  /* eslint-disable n/no-unsupported-features/node-builtins */
+   
   if (!neonConfig.webSocketConstructor && typeof WebSocket === 'undefined') {
     neonConfig.webSocketConstructor = ws
   }
-  /* eslint-enable n/no-unsupported-features/node-builtins */
+   
 }
 
 // Returns an HTTP client that lazily loads the connection string from the


### PR DESCRIPTION
When Blobs get a 401/403 during upload, the entire build fails - this is mostly prominent in the CLI. Often times, this 403 might happen because the signed URL that was generated has now expired between the retries, uploads, etc. There could be multiple causes for these 401s, 403s, but this was the only one I managed to actually hit via code. So while this might not solve all of these errors, for now, this PR now tries to:

- regenerate a fresh signed URL for the retry
- log response body in the error message so the actual error can be diagnosed instead of guessing