### PR TITLE
fix(blobs): return ETags and handle conditional reads locally

### DIFF
--- a/packages/blobs/src/server.test.ts
+++ b/packages/blobs/src/server.test.ts
@@ -554,6 +554,36 @@ test('Handles conditional writes', async () => {
   await fs.rm(directory.path, { force: true, recursive: true })
 })
 
+test('Returns ETags and handles conditional reads', async () => {
+  const directory = await tmp.dir()
+  const server = new BlobsServer({
+    directory: directory.path,
+    token,
+  })
+  const { port } = await server.start()
+  const store = getStore({
+    edgeURL: `http://localhost:${port}`,
+    name: 'my-store',
+    token,
+    siteID,
+  })
+  const key = 'conditional-key'
+  const value = 'value'
+  const metadata = { name: 'test-metadata', }
+
+  const writeResult = await store.set(key, value, { metadata })
+  const etag = writeResult.etag
+
+  expect(etag).toBeTypeOf('string')
+  expect(await store.getWithMetadata(key)).toEqual({ data: value, etag, metadata })
+  expect(await store.getMetadata(key)).toEqual({ etag, metadata })
+  expect(await store.getWithMetadata(key, { etag: '"stale-etag"' })).toEqual({ data: value, etag, metadata })
+  expect(await store.getWithMetadata(key, { etag })).toEqual({ data: null, etag, metadata })
+
+  await server.stop()
+  await fs.rm(directory.path, { force: true, recursive: true })
+})
+
 test('Deletes all blobs from a store', async () => {
   const directory = await tmp.dir()
   const server = new BlobsServer({

--- a/packages/blobs/src/server.ts
+++ b/packages/blobs/src/server.ts
@@ -210,7 +210,8 @@ export class BlobsServer {
 
     this.dispatchOnRequestEvent(Operation.GET, url)
 
-    const headers: Record<string, string> = {}
+    const etag = await BlobsServer.generateETag(dataPath)
+    const headers: Record<string, string> = { etag }
 
     try {
       const rawData = await fs.readFile(metadataPath, 'utf8')
@@ -224,6 +225,10 @@ export class BlobsServer {
       if (!isNodeError(error) || error.code !== 'ENOENT') {
         this.logDebug('Could not read metadata file:', error)
       }
+    }
+
+    if (req.headers.get('if-none-match') === etag) {
+      return new Response(null, { headers, status: 304 })
     }
 
     try {
@@ -260,9 +265,11 @@ export class BlobsServer {
       const rawData = await fs.readFile(metadataPath, 'utf8')
       const metadata = JSON.parse(rawData)
       const encodedMetadata = encodeMetadata(metadata)
+      const etag = await BlobsServer.generateETag(dataPath)
 
       return new Response(null, {
         headers: {
+          etag,
           [METADATA_HEADER_INTERNAL]: encodedMetadata ?? '',
         },
       })


### PR DESCRIPTION
`BlobsServer` does not include ETag headers in local `GET` or `HEAD` responses. `getWithMetadata("key")`, `getMetadata("key")` return `etag: undefined`, and `getWithMetadata("key", {etag: etag})` ignores the conditional request and returns the blob instead of `304 Not Modified` response. 

This change generates and returns the current ETag from the local `GET` and `HEAD` handlers. `GET` now also checks `If-None-Match` and returns `304` when it matches the current ETag. Also single regression test is added in `packages/blobs/src/server.test.ts`
 
### How to reproduce

```Typescript
import assert from "node:assert/strict";
  import { mkdtemp } from "node:fs/promises";
  import { tmpdir } from "node:os";
  import { join } from "node:path";
  import { getStore } from "@netlify/blobs";
  import { BlobsServer } from "@netlify/blobs/server";

  const server = new BlobsServer({
    directory: await mkdtemp(join(tmpdir(), "blobs-repro-")),
    token: "token",
  });

  try {
    const { address } = await server.start();
    const store = getStore({
      apiURL: address,
      name: "test",
      siteID: "site",
      token: "token",
    });

    const write = await store.set("key", "value");
    const get = await store.getWithMetadata("key");
    const head = await store.getMetadata("key");
    const conditional = await store.getWithMetadata("key", {
      etag: write.etag,
    });

    assert.equal(get?.etag, write.etag); // Fails before fix: undefined
    assert.equal(head?.etag, write.etag); // Fails before fix: undefined
    assert.equal(conditional?.data, null); // Fails before fix: "value"
  } finally {
    await server.stop();
  }
```

I found this whilst working on https://github.com/fedify-dev/fedify/issues/1010. I used 11.0.1 version. i could reproduce this with main branch.